### PR TITLE
Load Gemini key from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for development
+# Rename this file to .env and fill in your own values
+VITE_GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Setting up the Gemini API key
+
+1. Copy `.env.example` to `.env`.
+2. Add your Google Gemini API key to `VITE_GEMINI_API_KEY`.
+3. Restart the development server so Vite can pick up the changes.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/e7add94a-b181-432f-91dd-b205b8a3f9ed) and click on Share -> Publish.

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -9,8 +9,11 @@ interface SpecsRequest {
 }
 
 class GeminiServiceClass {
-  // Configuration fixe côté backend - clé API non visible aux utilisateurs
-  private apiKey: string = 'AIzaSyDXXXXX-VOTRE_CLE_API_ICI'; // À remplacer par votre vraie clé
+  // Clé API chargée via les variables d'environnement
+  private apiKey: string =
+    (import.meta as any).env?.VITE_GEMINI_API_KEY ||
+    (process.env as any).GEMINI_API_KEY ||
+    '';
   private dailyRequestCount: number = 0;
   private lastResetDate: string = '';
   private readonly MAX_DAILY_REQUESTS = 490; // Sécurité: 490 au lieu de 500


### PR DESCRIPTION
## Summary
- load Gemini API key from environment variables
- document environment variable in `.env.example`
- add setup instructions for API key in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686b81ffd8948330862f5be81c23b1e9