### PR TITLE
Implement Gemini multi-product comparison

### DIFF
--- a/src/components/MultiCompareResults.tsx
+++ b/src/components/MultiCompareResults.tsx
@@ -17,37 +17,33 @@ import { useToast } from '@/hooks/use-toast';
 import html2canvas from 'html2canvas';
 import * as XLSX from 'xlsx';
 
+interface ProductData {
+  name: string;
+  scores: Record<string, number>;
+  overallScore: number;
+  recommendation: string;
+  affiliateLink?: string;
+}
+
+interface MultiComparisonData {
+  categories: string[];
+  products: ProductData[];
+}
+
 interface MultiCompareResultsProps {
-  products: string[];
+  data: MultiComparisonData;
   plan: 'basic' | 'premium';
   onClose: () => void;
   onBackToForm: () => void;
 }
 
-const MultiCompareResults = ({ products, plan, onClose, onBackToForm }: MultiCompareResultsProps) => {
+const MultiCompareResults = ({ data, plan, onClose, onBackToForm }: MultiCompareResultsProps) => {
   const [isConnoisseurView, setIsConnoisseurView] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const { toast } = useToast();
   const exportRef = useRef<HTMLDivElement>(null);
 
-  // Données simulées pour la démonstration
-  const comparisonData = {
-    categories: ['Performance', 'Price', 'Battery Life', 'Display', 'Storage', 'Camera'],
-    products: products.map((product, index) => ({
-      name: product,
-      scores: {
-        'Performance': Math.floor(Math.random() * 40) + 60,
-        'Price': Math.floor(Math.random() * 30) + 70,
-        'Battery Life': Math.floor(Math.random() * 35) + 65,
-        'Display': Math.floor(Math.random() * 25) + 75,
-        'Storage': Math.floor(Math.random() * 30) + 70,
-        'Camera': Math.floor(Math.random() * 20) + 80
-      },
-      overallScore: Math.floor(Math.random() * 25) + 75,
-      recommendation: index === 0 ? 'Best Choice' : index === 1 ? 'Good Value' : 'Consider',
-      affiliateLink: `https://example-store.com/search?q=${encodeURIComponent(product)}&ref=isbetter`
-    }))
-  };
+  const comparisonData = data;
 
   const handleExportImage = async () => {
     if (!exportRef.current) return;
@@ -183,7 +179,7 @@ const MultiCompareResults = ({ products, plan, onClose, onBackToForm }: MultiCom
               </button>
               <div>
                 <h2 className="text-2xl font-bold text-tech-dark">Multi-Product Analysis</h2>
-                <p className="text-tech-gray-600">{products.length} products compared • {plan} plan</p>
+                <p className="text-tech-gray-600">{comparisonData.products.length} products compared • {plan} plan</p>
               </div>
             </div>
             <div className="flex items-center space-x-3">

--- a/src/services/backendService.ts
+++ b/src/services/backendService.ts
@@ -31,12 +31,23 @@ class BackendServiceClass {
     }
   }
 
+  async getMultiComparison(products: string[]): Promise<any> {
+    try {
+      return await geminiService.getMultiComparison(products);
+    } catch (error) {
+      console.error('Multi comparison error:', error);
+      throw error;
+    }
+  }
+
   async processRequest(type: string, data: any): Promise<any> {
     switch (type) {
       case 'comparison':
         return this.getProductComparison(data.currentDevice, data.newDevice);
       case 'specs':
         return this.getProductSpecs(data.productName);
+      case 'multi-comparison':
+        return this.getMultiComparison(data.products);
       default:
         throw new Error(`Unknown request type: ${type}`);
     }

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -170,6 +170,31 @@ Be accurate and comprehensive.`;
     return this.parseGeminiResponse(response);
   }
 
+  async getMultiComparison(products: string[]): Promise<any> {
+    const prompt = `Compare the following products and provide an overall analysis table:
+
+${products.join('\n')}
+
+Respond with a JSON object like:
+{
+  "categories": ["Performance", "Price", "Battery", "Display", "Storage", "Camera"],
+  "products": [
+    {
+      "name": "Product name",
+      "scores": { "Performance": 90, "Price": 80, ... },
+      "overallScore": 85,
+      "recommendation": "Best Choice",
+      "affiliateLink": "https://example.com"
+    }
+  ]
+}
+
+Only provide valid JSON.`;
+
+    const response = await this.callGeminiAPI(prompt);
+    return this.parseGeminiResponse(response);
+  }
+
   private parseGeminiResponse(response: any): any {
     try {
       const text = response.candidates?.[0]?.content?.parts?.[0]?.text;

--- a/src/services/queueService.ts
+++ b/src/services/queueService.ts
@@ -2,7 +2,7 @@
 interface QueuedRequest {
   id: string;
   priority: 'high' | 'normal' | 'low';
-  type: 'comparison' | 'specs' | 'cache-update';
+  type: 'comparison' | 'specs' | 'cache-update' | 'multi-comparison';
   data: any;
   resolve: (value: any) => void;
   reject: (error: any) => void;


### PR DESCRIPTION
## Summary
- add `getMultiComparison` to `geminiService`
- extend backend and queue services to support multi-comparison tasks
- fetch multi-comparison data via queue after payment
- display Gemini results instead of random data in `MultiCompareResults`

## Testing
- `npm install`
- `npm run build`
- `npm run lint` *(fails: 24 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ab5fc4f6c83309f78855f38f26363