### PR TITLE
Add Gemini proxy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,10 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Gemini API setup
+
+Requests to Google Gemini are now proxied through `/api/gemini`. Configure an environment
+variable called `GEMINI_API_KEY` on your hosting platform so the serverless
+function can authenticate with Google. The key no longer needs to be exposed to
+the front-end.

--- a/api/gemini.ts
+++ b/api/gemini.ts
@@ -1,0 +1,29 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+
+const GEMINI_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY
+  if (!apiKey) {
+    res.status(500).json({ error: 'GEMINI_API_KEY not configured' })
+    return
+  }
+
+  try {
+    const response = await fetch(`${GEMINI_ENDPOINT}?key=${apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body)
+    })
+
+    const data = await response.json()
+    res.status(response.status).json(data)
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to contact Gemini API' })
+  }
+}

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -9,12 +9,10 @@ interface SpecsRequest {
 }
 
 class GeminiServiceClass {
-  // Configuration fixe côté backend - clé API non visible aux utilisateurs
-  private apiKey: string = 'AIzaSyDXXXXX-VOTRE_CLE_API_ICI'; // À remplacer par votre vraie clé
+  // Quota management handled client side; API key lives on the server
   private dailyRequestCount: number = 0;
   private lastResetDate: string = '';
   private readonly MAX_DAILY_REQUESTS = 490; // Sécurité: 490 au lieu de 500
-  private readonly GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
   private readonly ADMIN_EMAIL = 'votre-email@example.com'; // Email pour les alertes
 
   constructor() {
@@ -97,32 +95,16 @@ class GeminiServiceClass {
   }
 
   private async callGeminiAPI(prompt: string): Promise<any> {
-    if (!this.apiKey || this.apiKey.includes('XXXX')) {
-      throw new Error('Clé API Gemini non configurée côté serveur - Contactez l\'administrateur');
-    }
-
     if (!this.checkDailyLimit()) {
       throw new Error(`Service temporairement indisponible. Réessayez demain.`);
     }
 
-    const response = await fetch(`${this.GEMINI_API_URL}?key=${this.apiKey}`, {
+    const response = await fetch('/api/gemini', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        contents: [{
-          parts: [{
-            text: prompt
-          }]
-        }],
-        generationConfig: {
-          temperature: 0.7,
-          topK: 40,
-          topP: 0.95,
-          maxOutputTokens: 2048,
-        }
-      })
+      body: JSON.stringify({ prompt })
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- create `api/gemini.ts` serverless function that proxies requests to Google using `GEMINI_API_KEY`
- update `geminiService.ts` to call the new backend endpoint
- document the `GEMINI_API_KEY` env variable

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686aafbb1a5483309a1b463357354a86