### PR TITLE
Fix cache retrieval in mock data hook

### DIFF
--- a/src/hooks/useMockData.ts
+++ b/src/hooks/useMockData.ts
@@ -75,8 +75,8 @@ export const useMockData = () => {
       // Check cache first
       const cacheKey = `${currentDevice}|${newDevice}`;
       const cachedResult = cacheService.get('COMPARISON', cacheKey);
-      
-      if (cachedResult && !cachedResult._expired) {
+
+      if (cachedResult) {
         console.log('Using cached comparison data');
         setIsLoading(false);
         return cachedResult;


### PR DESCRIPTION
## Summary
- fix incorrect cache check

## Testing
- `npm run lint` *(fails: cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_686a439a47a483308c09d91381d666e7