### PR TITLE
Add detailed error logging in dev mode

### DIFF
--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useMockData } from '@/hooks/useMockData';
+import { logDevError } from '@/lib/devLogger';
 import { geminiService } from '@/services/geminiService';
 import { useToast } from '@/hooks/use-toast';
 
@@ -123,6 +124,7 @@ export const useComparisonForm = () => {
         setComparisonResult(result);
       } catch (error) {
         console.error('Comparison failed:', error);
+        logDevError('Comparison failed', error);
         toast({
           title: 'Analysis Error',
           description: 'Unable to analyze these products. Please try again later.',
@@ -148,6 +150,7 @@ export const useComparisonForm = () => {
       setComparisonResult(result);
     } catch (error) {
       console.error('Precise analysis failed:', error);
+      logDevError('Precise analysis failed', error);
       toast({
         title: 'Analysis Error',
         description: 'Unable to analyze these products. Please try again later.',
@@ -172,6 +175,7 @@ export const useComparisonForm = () => {
         .then(result => setComparisonResult(result))
         .catch(error => {
           console.error('Comparison failed:', error);
+          logDevError('Comparison failed', error);
           toast({
             title: 'Analysis Error',
             description: 'Unable to analyze these products. Please try again later.',
@@ -195,6 +199,7 @@ export const useComparisonForm = () => {
       setComparisonResult(result);
     } catch (error) {
       console.error('Comparison failed:', error);
+      logDevError('Comparison failed', error);
       toast({
         title: 'Analysis Error',
         description: 'Unable to analyze these products. Please try again later.',

--- a/src/hooks/useMockData.ts
+++ b/src/hooks/useMockData.ts
@@ -3,6 +3,7 @@ import { mockModels, type ModelOption } from '@/data/mockModels';
 import { areProductsComparable, generateIncompatibleExplanation } from '@/utils/productCategories';
 import { queueService } from '@/services/queueService';
 import { cacheService } from '@/services/cacheService';
+import { logDevError } from '@/lib/devLogger';
 
 interface ComparisonData {
   currentDevice: string;
@@ -98,12 +99,14 @@ export const useMockData = () => {
 
       } catch (error) {
         console.error('Failed to get real data:', error);
+        logDevError('Failed to get real data', error);
         setIsLoading(false);
         throw error;
       }
       
     } catch (error) {
       console.error('Analysis failed:', error);
+      logDevError('Analysis failed', error);
       setIsLoading(false);
       throw error;
     }

--- a/src/lib/devLogger.ts
+++ b/src/lib/devLogger.ts
@@ -1,0 +1,9 @@
+export function logDevError(context: string, error: unknown): void {
+  if (import.meta.env.DEV) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.error(`[DEV] ${context}:`, err.message);
+    if (err.stack) {
+      console.error(err.stack);
+    }
+  }
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,9 @@ import MultiCompare from '@/components/MultiCompare';
 const Index = () => {
   const [showMultiCompare, setShowMultiCompare] = useState(false);
   return <div className="min-h-screen bg-gradient-to-br from-tech-gray-50 via-white to-tech-neon/5 font-sans">
+      <div className="bg-tech-gray-100 text-tech-gray-700 text-center text-sm py-2 border-b border-tech-gray-200">
+        Ceci est la maj du 090725-1320
+      </div>
       <Header />
 
       <main className="container mx-auto px-6">

--- a/src/services/queueService.ts
+++ b/src/services/queueService.ts
@@ -1,4 +1,6 @@
 
+import { logDevError } from '@/lib/devLogger';
+
 interface QueuedRequest {
   id: string;
   priority: 'high' | 'normal' | 'low';
@@ -76,6 +78,7 @@ class QueueService {
         request.resolve(result);
       } catch (error) {
         console.error('Queue processing error:', error);
+        logDevError('Queue processing error', error);
         request.reject(error);
       }
 


### PR DESCRIPTION
## Summary
- implement `logDevError` helper
- use `logDevError` in comparison and mock hooks and queue service
- add update notice banner to the home page

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686e4e3be4b88330bf0e0c0ecbeb306e