### PR TITLE
Add JSON repair for Gemini responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "embla-carousel-react": "^8.3.0",
         "html2canvas": "^1.4.1",
         "input-otp": "^1.2.4",
+        "jsonrepair": "^3.12.0",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "react": "^18.3.1",
@@ -5206,6 +5207,15 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.12.0.tgz",
+      "integrity": "sha512-SWfjz8SuQ0wZjwsxtSJ3Zy8vvLg6aO/kxcp9TWNPGwJKgTZVfhNEQBMk/vPOpYCDFWRxD6QWuI6IHR1t615f0w==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "embla-carousel-react": "^8.3.0",
     "html2canvas": "^1.4.1",
     "input-otp": "^1.2.4",
+    "jsonrepair": "^3.12.0",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -1,5 +1,6 @@
 
 import { sanitizeInput } from '@/utils/sanitize';
+import { parseGeminiResponse } from '@/utils/parseGeminiResponse';
 
 interface GeminiRequest {
   currentDevice: string;
@@ -157,7 +158,7 @@ Please respond with a JSON object containing:
 Focus on performance, features, value, and user experience. Be objective and helpful.`;
 
     const response = await this.callGeminiAPI(prompt);
-    return this.parseGeminiResponse(response);
+    return parseGeminiResponse(response);
   }
 
   async getProductSpecs(productName: string): Promise<any> {
@@ -174,7 +175,7 @@ Please respond with a JSON object containing comprehensive specs including:
 Be accurate and comprehensive.`;
 
     const response = await this.callGeminiAPI(prompt);
-    return this.parseGeminiResponse(response);
+    return parseGeminiResponse(response);
   }
 
   async getMultiComparison(products: string[]): Promise<any> {
@@ -199,28 +200,9 @@ Respond with a JSON object like:
 Only provide valid JSON.`;
 
     const response = await this.callGeminiAPI(prompt);
-    return this.parseGeminiResponse(response);
+    return parseGeminiResponse(response);
   }
 
-  private parseGeminiResponse(response: any): any {
-    try {
-      const text = response.candidates?.[0]?.content?.parts?.[0]?.text;
-      if (!text) {
-        throw new Error('Invalid response format from Gemini');
-      }
-
-      // Try to extract JSON from the response
-      const jsonMatch = text.match(/\{[\s\S]*\}/);
-      if (jsonMatch) {
-        return JSON.parse(jsonMatch[0]);
-      }
-      
-      throw new Error('No JSON found in Gemini response');
-    } catch (error) {
-      console.error('Error parsing Gemini response:', error);
-      throw new Error('Erreur lors du traitement de la réponse IA');
-    }
-  }
 
   getDailyUsage() {
     return {

--- a/src/utils/parseGeminiResponse.ts
+++ b/src/utils/parseGeminiResponse.ts
@@ -1,0 +1,26 @@
+import { jsonrepair } from 'jsonrepair';
+
+export function parseGeminiResponse(response: any): any {
+  const text = response?.candidates?.[0]?.content?.parts?.[0]?.text;
+  if (!text) {
+    throw new Error('Invalid response format from Gemini');
+  }
+
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error('No JSON found in Gemini response');
+  }
+
+  const jsonString = jsonMatch[0];
+  try {
+    return JSON.parse(jsonString);
+  } catch {
+    try {
+      const repaired = jsonrepair(jsonString);
+      return JSON.parse(repaired);
+    } catch (error) {
+      console.error('Error repairing Gemini JSON:', error);
+      throw new Error('Erreur lors du traitement de la réponse IA');
+    }
+  }
+}

--- a/tests/parseGeminiResponse.test.ts
+++ b/tests/parseGeminiResponse.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { parseGeminiResponse } from '../src/utils/parseGeminiResponse';
+
+const buildResponse = (text: string) => ({
+  candidates: [
+    { content: { parts: [{ text }] } }
+  ]
+});
+
+describe('parseGeminiResponse', () => {
+  it('repairs malformed JSON with trailing comma', () => {
+    const malformed = `Here is the data:\n{\n  "name": "John",\n  "age": 30,\n}`;
+    const response = buildResponse(malformed);
+    const result = parseGeminiResponse(response);
+    expect(result).toEqual({ name: 'John', age: 30 });
+  });
+});


### PR DESCRIPTION
## Summary
- add jsonrepair dependency
- create utility to parse and repair Gemini JSON output
- update gemini service to use the new parser
- cover JSON repair with a unit test

## Testing
- `npx vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ec3dc7c9083308cc896bfc5c5db8f