### PR TITLE
Fix sanitizeInput test quotes

### DIFF
--- a/tests/sanitize.test.ts
+++ b/tests/sanitize.test.ts
@@ -11,8 +11,8 @@ describe('sanitizeInput', () => {
   });
 
   it('escapes quotes and backticks', () => {
-    const input = "He said \"hi\" and it's ok";
-    expect(sanitizeInput(input)).toBe(`He said \\\"hi\\\" and it\\'s ok`);
+    const input = 'He said "hi" and it\'s ok';
+    expect(sanitizeInput(input)).toBe('He said \\\"hi\\\" and it\\\'s ok');
   });
 
   it('handles injection attempts', () => {


### PR DESCRIPTION
## Summary
- use single quotes for sanitize test expectation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ec3e236508330a93f81d4d64c3f47