### PR TITLE
Fix Gemini response parsing

### DIFF
--- a/src/utils/parseGeminiResponse.ts
+++ b/src/utils/parseGeminiResponse.ts
@@ -1,7 +1,16 @@
 import { jsonrepair } from 'jsonrepair';
 
 export function parseGeminiResponse(response: any): any {
-  const text = response?.candidates?.[0]?.content?.parts?.[0]?.text;
+  const parts = response?.candidates?.[0]?.content?.parts;
+  let text: string | undefined;
+  if (Array.isArray(parts)) {
+    for (const part of parts) {
+      if (typeof part.text === 'string') {
+        text = part.text;
+        break;
+      }
+    }
+  }
   if (!text) {
     throw new Error('Invalid response format from Gemini');
   }

--- a/tests/parseGeminiResponse.test.ts
+++ b/tests/parseGeminiResponse.test.ts
@@ -14,4 +14,21 @@ describe('parseGeminiResponse', () => {
     const result = parseGeminiResponse(response);
     expect(result).toEqual({ name: 'John', age: 30 });
   });
+
+  it('finds the first text part if initial part has no text', () => {
+    const response = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              { inlineData: { data: 'ignored', mimeType: 'text/plain' } },
+              { text: '{"ok":true}' }
+            ]
+          }
+        }
+      ]
+    } as any;
+    const result = parseGeminiResponse(response);
+    expect(result).toEqual({ ok: true });
+  });
 });


### PR DESCRIPTION
## Summary
- handle Gemini responses where the first part has no text
- add regression test covering the new parsing logic

## Testing
- `npm test -- -t parseGeminiResponse`

------
https://chatgpt.com/codex/tasks/task_e_686ede5f63388330a107d59526c4573a