### PR TITLE
Reduce Gemini output length

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ cp .env.example .env
 ```
 
 The application uses the free Gemini 2.5 Flash model with a daily limit of 500 requests. The code enforces a safety threshold of 490 requests per day to avoid hitting the quota.
+Responses are limited to 1024 tokens to encourage concise answers and reduce quota usage.

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -127,7 +127,8 @@ class GeminiServiceClass {
           temperature: 0.7,
           topK: 40,
           topP: 0.95,
-          maxOutputTokens: 2048,
+          // Limit output length to keep responses concise
+          maxOutputTokens: 1024,
         }
       })
     });


### PR DESCRIPTION
## Summary
- limit Gemini API responses to 1024 tokens
- document the new limit in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eeeebe1a8833099255d1b6db31458