### PR TITLE
Update gemini token limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ cp .env.example .env
 ```
 
 The application uses the free Gemini 2.5 Flash model with a daily limit of 500 requests. The code enforces a safety threshold of 490 requests per day to avoid hitting the quota.
-Responses are limited to 1024 tokens to encourage concise answers and reduce quota usage.
+Responses are limited to 4096 tokens to encourage concise answers and reduce quota usage.

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -129,7 +129,7 @@ class GeminiServiceClass {
           topK: 40,
           topP: 0.95,
           // Limit output length to keep responses concise
-          maxOutputTokens: 1024,
+          maxOutputTokens: 4096,
         }
       })
     });


### PR DESCRIPTION
## Summary
- allow larger Gemini responses by raising `maxOutputTokens` to 4096
- document new response limit in README

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686f826eebf08330bf4df597f952709b