### PR TITLE
Add precise specs to comparison query key

### DIFF
--- a/src/hooks/useComparison.js
+++ b/src/hooks/useComparison.js
@@ -1,0 +1,21 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { backendService } from '@/services/backendService';
+import { useEffect } from 'react';
+
+export const useComparison = (currentProduct, newProduct, preciseSpecs) => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (preciseSpecs) {
+      queryClient.invalidateQueries(['comparison', currentProduct, newProduct]);
+    }
+  }, [preciseSpecs, currentProduct, newProduct, queryClient]);
+
+  return useQuery(
+    ['comparison', currentProduct, newProduct, preciseSpecs],
+    () => backendService.getProductComparison(currentProduct, newProduct),
+    {
+      enabled: Boolean(currentProduct && newProduct)
+    }
+  );
+};


### PR DESCRIPTION
## Summary
- add new React Query hook `useComparison`
- include `preciseSpecs` in cache key and invalidate old comparison results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fa8600c20833084fca1aa11c3add3