### PR TITLE
Add dialog descriptions for accessibility

### DIFF
--- a/src/components/PreciseSpecsDialog.tsx
+++ b/src/components/PreciseSpecsDialog.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -44,13 +44,19 @@ const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit }: PreciseSpecsDialogPro
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-lg max-h-[80vh] overflow-y-auto">
+      <DialogContent
+        className="sm:max-w-lg max-h-[80vh] overflow-y-auto"
+        aria-describedby="precise-specs-desc"
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <Settings className="h-5 w-5 text-blue-500" />
             <span>Specify Precise Specifications</span>
           </DialogTitle>
         </DialogHeader>
+        <DialogDescription id="precise-specs-desc">
+          Provide detailed hardware specifications for a more accurate comparison.
+        </DialogDescription>
         
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-4">

--- a/src/components/ProductNotFoundDialog.tsx
+++ b/src/components/ProductNotFoundDialog.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Search, Lightbulb } from 'lucide-react';
 
@@ -21,14 +21,17 @@ const ProductNotFoundDialog = ({ isOpen, onClose, searchTerm }: ProductNotFoundD
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" aria-describedby="product-not-found-desc">
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <Search className="h-5 w-5 text-red-500" />
             <span>Product Not Found</span>
           </DialogTitle>
         </DialogHeader>
-        
+        <DialogDescription id="product-not-found-desc">
+          This dialog shows search tips when no matching product is found.
+        </DialogDescription>
+
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
             We couldn't find "<span className="font-semibold">{searchTerm}</span>" in our database.

--- a/src/components/QueueDialog.tsx
+++ b/src/components/QueueDialog.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect, useRef } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { Clock, Users, Crown, CreditCard, Gamepad2 } from 'lucide-react';
@@ -119,13 +119,16 @@ const QueueDialog = ({ isOpen, onClose }: QueueDialogProps) => {
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg" aria-describedby="queue-desc">
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <Users className="h-5 w-5 text-orange-500" />
             <span>Queue Active</span>
           </DialogTitle>
         </DialogHeader>
+        <DialogDescription id="queue-desc">
+          Displays your current queue position and wait options.
+        </DialogDescription>
         
         <div className="space-y-6">
           <div className="text-center">


### PR DESCRIPTION
## Summary
- describe ProductNotFound dialog content and link it with aria-describedby
- describe PreciseSpecs dialog content for screen readers
- describe Queue dialog purpose with aria-describedby

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686faad7eee4833099102372a3871bd9