### PR TITLE
Fix layout thrash in pong game

### DIFF
--- a/src/components/QueueDialog.tsx
+++ b/src/components/QueueDialog.tsx
@@ -12,11 +12,15 @@ interface QueueDialogProps {
 
 const PongGame = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRectRef = useRef<DOMRect | null>(null);
   const [score, setScore] = useState(0);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
+
+    // Cache canvas bounds once to avoid layout thrashing
+    canvasRectRef.current = canvas.getBoundingClientRect();
 
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
@@ -73,7 +77,8 @@ const PongGame = () => {
     };
 
     const handleMouseMove = (e: MouseEvent) => {
-      const rect = canvas.getBoundingClientRect();
+      const rect = canvasRectRef.current;
+      if (!rect) return;
       paddle.x = e.clientX - rect.left - paddle.width / 2;
     };
 


### PR DESCRIPTION
## Summary
- cache the canvas bounding rect on mount
- reuse cached rect during paddle movement

## Testing
- `npm run lint`
- `npm test` *(passes then enters watch mode; exited)*


------
https://chatgpt.com/codex/tasks/task_e_686faccc092083309679a0c861e47230