### PR TITLE
Add Snake game loader and improved spec dialog

### DIFF
--- a/src/components/ComparisonDialogs.tsx
+++ b/src/components/ComparisonDialogs.tsx
@@ -13,6 +13,8 @@ interface ComparisonDialogsProps {
   showPreciseSpecs: boolean;
   setShowPreciseSpecs: (show: boolean) => void;
   onPreciseSpecsSubmit: (specs: any) => void;
+  onSkipPreciseSpecs: () => void;
+  isPaidUser?: boolean;
 }
 
 const ComparisonDialogs = ({
@@ -23,7 +25,9 @@ const ComparisonDialogs = ({
   setShowQueue,
   showPreciseSpecs,
   setShowPreciseSpecs,
-  onPreciseSpecsSubmit
+  onPreciseSpecsSubmit,
+  onSkipPreciseSpecs,
+  isPaidUser
 }: ComparisonDialogsProps) => {
   return (
     <>
@@ -42,6 +46,8 @@ const ComparisonDialogs = ({
         isOpen={showPreciseSpecs}
         onClose={() => setShowPreciseSpecs(false)}
         onSubmit={onPreciseSpecsSubmit}
+        onSkip={onSkipPreciseSpecs}
+        isPaidUser={isPaidUser}
       />
     </>
   );

--- a/src/components/ComparisonForm.tsx
+++ b/src/components/ComparisonForm.tsx
@@ -32,6 +32,7 @@ const ComparisonForm = () => {
     setShowPreciseSpecs,
     handleSubmit,
     handlePreciseSpecsSubmit,
+    handleSkipPreciseSpecs,
     handleCurrentModelSelect,
     handleNewModelSelect,
     resetForm
@@ -115,6 +116,8 @@ const ComparisonForm = () => {
         showPreciseSpecs={showPreciseSpecs}
         setShowPreciseSpecs={setShowPreciseSpecs}
         onPreciseSpecsSubmit={handlePreciseSpecsSubmit}
+        onSkipPreciseSpecs={handleSkipPreciseSpecs}
+        isPaidUser={false}
       />
     </>
   );

--- a/src/components/ComparisonFormInputs.tsx
+++ b/src/components/ComparisonFormInputs.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent } from '@/components/ui/card';
 import { Search, Loader2 } from 'lucide-react';
+import SnakeGame from '@/components/SnakeGame';
 
 interface ComparisonFormInputsProps {
   currentProduct: string;
@@ -101,6 +102,14 @@ const ComparisonFormInputs = ({
               )}
             </Button>
           </form>
+          {isLoading && (
+            <div className="mt-6 space-y-4 text-center">
+              <p className="text-sm text-tech-gray-500">
+                Interrogating the AI, this might take a moment… Enjoy a little game in the meantime?
+              </p>
+              <SnakeGame active={isLoading} />
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/components/PreciseSpecsDialog.tsx
+++ b/src/components/PreciseSpecsDialog.tsx
@@ -10,7 +10,9 @@ import { Settings, Cpu, HardDrive, Monitor, Battery } from 'lucide-react';
 interface PreciseSpecsDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (specs: PreciseSpecs) => void;
+  onSubmit: (specs: PreciseSpecs[]) => void;
+  onSkip: () => void;
+  isPaidUser?: boolean;
 }
 
 interface PreciseSpecs {
@@ -22,24 +24,39 @@ interface PreciseSpecs {
   additionalSpecs: string;
 }
 
-const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit }: PreciseSpecsDialogProps) => {
-  const [specs, setSpecs] = useState<PreciseSpecs>({
-    processor: '',
-    ram: '',
-    storage: '',
-    display: '',
-    battery: '',
-    additionalSpecs: ''
-  });
+const emptySpecs: PreciseSpecs = {
+  processor: '',
+  ram: '',
+  storage: '',
+  display: '',
+  battery: '',
+  additionalSpecs: ''
+};
+
+const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit, onSkip, isPaidUser = false }: PreciseSpecsDialogProps) => {
+  const [specsList, setSpecsList] = useState<PreciseSpecs[]>([ { ...emptySpecs } ]);
+
+  const addDevice = () => {
+    if (!isPaidUser && specsList.length >= 2) return;
+    setSpecsList(prev => [...prev, { ...emptySpecs }]);
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit(specs);
+    onSubmit(specsList);
     onClose();
   };
 
-  const handleInputChange = (field: keyof PreciseSpecs, value: string) => {
-    setSpecs(prev => ({ ...prev, [field]: value }));
+  const handleInputChange = (
+    index: number,
+    field: keyof PreciseSpecs,
+    value: string
+  ) => {
+    setSpecsList(prev => {
+      const copy = [...prev];
+      copy[index] = { ...copy[index], [field]: value };
+      return copy;
+    });
   };
 
   return (
@@ -59,97 +76,99 @@ const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit }: PreciseSpecsDialogPro
         </DialogDescription>
         
         <form onSubmit={handleSubmit} className="space-y-6">
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="processor" className="flex items-center space-x-2">
-                <Cpu className="h-4 w-4 text-blue-600" />
-                <span>Processor</span>
-              </Label>
-              <Input
-                id="processor"
-                placeholder="e.g., Apple M3, Intel Core i7-13700H"
-                value={specs.processor}
-                onChange={(e) => handleInputChange('processor', e.target.value)}
-              />
+          {specsList.map((specs, idx) => (
+            <div key={idx} className="space-y-4 border-b pb-4 last:border-none last:pb-0">
+              <h3 className="font-semibold">Device {idx + 1}</h3>
+              <div className="space-y-2">
+                <Label htmlFor={`processor-${idx}`} className="flex items-center space-x-2">
+                  <Cpu className="h-4 w-4 text-blue-600" />
+                  <span>Processor</span>
+                </Label>
+                <Input
+                  id={`processor-${idx}`}
+                  placeholder="e.g., Apple M3, Intel Core i7-13700H"
+                  value={specs.processor}
+                  onChange={(e) => handleInputChange(idx, 'processor', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`ram-${idx}`} className="flex items-center space-x-2">
+                  <HardDrive className="h-4 w-4 text-green-600" />
+                  <span>RAM</span>
+                </Label>
+                <Input
+                  id={`ram-${idx}`}
+                  placeholder="e.g., 16GB LPDDR5, 32GB DDR4"
+                  value={specs.ram}
+                  onChange={(e) => handleInputChange(idx, 'ram', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`storage-${idx}`} className="flex items-center space-x-2">
+                  <HardDrive className="h-4 w-4 text-purple-600" />
+                  <span>Storage</span>
+                </Label>
+                <Input
+                  id={`storage-${idx}`}
+                  placeholder="e.g., 512GB SSD, 1TB NVMe"
+                  value={specs.storage}
+                  onChange={(e) => handleInputChange(idx, 'storage', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`display-${idx}`} className="flex items-center space-x-2">
+                  <Monitor className="h-4 w-4 text-orange-600" />
+                  <span>Display</span>
+                </Label>
+                <Input
+                  id={`display-${idx}`}
+                  placeholder='e.g., 13.6" Liquid Retina, 15.6" OLED 4K'
+                  value={specs.display}
+                  onChange={(e) => handleInputChange(idx, 'display', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`battery-${idx}`} className="flex items-center space-x-2">
+                  <Battery className="h-4 w-4 text-red-600" />
+                  <span>Battery Life</span>
+                </Label>
+                <Input
+                  id={`battery-${idx}`}
+                  placeholder="e.g., 18 hours, 5000mAh"
+                  value={specs.battery}
+                  onChange={(e) => handleInputChange(idx, 'battery', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`additional-${idx}`}>Additional Specifications</Label>
+                <Textarea
+                  id={`additional-${idx}`}
+                  placeholder="Any other important specs (GPU, ports, weight, etc.)"
+                  value={specs.additionalSpecs}
+                  onChange={(e) => handleInputChange(idx, 'additionalSpecs', e.target.value)}
+                  rows={3}
+                />
+              </div>
             </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="ram" className="flex items-center space-x-2">
-                <HardDrive className="h-4 w-4 text-green-600" />
-                <span>RAM</span>
-              </Label>
-              <Input
-                id="ram"
-                placeholder="e.g., 16GB LPDDR5, 32GB DDR4"
-                value={specs.ram}
-                onChange={(e) => handleInputChange('ram', e.target.value)}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="storage" className="flex items-center space-x-2">
-                <HardDrive className="h-4 w-4 text-purple-600" />
-                <span>Storage</span>
-              </Label>
-              <Input
-                id="storage"
-                placeholder="e.g., 512GB SSD, 1TB NVMe"
-                value={specs.storage}
-                onChange={(e) => handleInputChange('storage', e.target.value)}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="display" className="flex items-center space-x-2">
-                <Monitor className="h-4 w-4 text-orange-600" />
-                <span>Display</span>
-              </Label>
-              <Input
-                id="display"
-                placeholder="e.g., 13.6&quot; Liquid Retina, 15.6&quot; OLED 4K"
-                value={specs.display}
-                onChange={(e) => handleInputChange('display', e.target.value)}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="battery" className="flex items-center space-x-2">
-                <Battery className="h-4 w-4 text-red-600" />
-                <span>Battery Life</span>
-              </Label>
-              <Input
-                id="battery"
-                placeholder="e.g., 18 hours, 5000mAh"
-                value={specs.battery}
-                onChange={(e) => handleInputChange('battery', e.target.value)}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="additionalSpecs">Additional Specifications</Label>
-              <Textarea
-                id="additionalSpecs"
-                placeholder="Any other important specs (GPU, ports, weight, etc.)"
-                value={specs.additionalSpecs}
-                onChange={(e) => handleInputChange('additionalSpecs', e.target.value)}
-                rows={3}
-              />
-            </div>
-          </div>
-
+          ))}
+          {(isPaidUser || specsList.length < 2) && (
+            <Button type="button" variant="outline" onClick={addDevice}>
+              Add Another Device
+            </Button>
+          )}
           <div className="bg-blue-50 p-3 rounded-lg">
             <p className="text-sm text-blue-800">
               <strong>Tip:</strong> The more precise you are with specifications, the more accurate our comparison will be!
             </p>
           </div>
-          
-          <div className="flex justify-end space-x-2">
+          <div className="flex flex-col sm:flex-row sm:justify-end sm:space-x-2 space-y-2 sm:space-y-0">
+            <Button type="button" variant="ghost" onClick={onSkip}>
+              Whatever, just compare the most common configuration.
+            </Button>
             <Button type="button" variant="outline" onClick={onClose}>
               Cancel
             </Button>
-            <Button type="submit">
-              Analyze with Precise Specs
-            </Button>
+            <Button type="submit">Analyze with Precise Specs</Button>
           </div>
         </form>
       </DialogContent>

--- a/src/components/SnakeGame.tsx
+++ b/src/components/SnakeGame.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface Point { x: number; y: number }
+
+const BOARD_SIZE = 10;
+const INITIAL_SNAKE: Point[] = [{ x: 4, y: 4 }];
+
+function randomFood(): Point {
+  return {
+    x: Math.floor(Math.random() * BOARD_SIZE),
+    y: Math.floor(Math.random() * BOARD_SIZE)
+  };
+}
+
+interface SnakeGameProps {
+  active: boolean;
+}
+
+const SnakeGame = ({ active }: SnakeGameProps) => {
+  const [snake, setSnake] = useState<Point[]>(INITIAL_SNAKE);
+  const [food, setFood] = useState<Point>(randomFood());
+  const directionRef = useRef<Point>({ x: 1, y: 0 });
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowUp') directionRef.current = { x: 0, y: -1 };
+      else if (e.key === 'ArrowDown') directionRef.current = { x: 0, y: 1 };
+      else if (e.key === 'ArrowLeft') directionRef.current = { x: -1, y: 0 };
+      else if (e.key === 'ArrowRight') directionRef.current = { x: 1, y: 0 };
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => {
+      setSnake(prev => {
+        const head = prev[0];
+        const newHead = {
+          x: (head.x + directionRef.current.x + BOARD_SIZE) % BOARD_SIZE,
+          y: (head.y + directionRef.current.y + BOARD_SIZE) % BOARD_SIZE
+        };
+        const newSnake = [newHead, ...prev.slice(0, prev.length - 1)];
+        if (newHead.x === food.x && newHead.y === food.y) {
+          setFood(randomFood());
+          newSnake.push(prev[prev.length - 1]);
+        }
+        return newSnake;
+      });
+    }, 200);
+    return () => clearInterval(id);
+  }, [active, food]);
+
+  return (
+    <div className="grid grid-cols-10 gap-0.5 w-40 mx-auto">
+      {Array.from({ length: BOARD_SIZE * BOARD_SIZE }).map((_, i) => {
+        const x = i % BOARD_SIZE;
+        const y = Math.floor(i / BOARD_SIZE);
+        const isSnake = snake.some(p => p.x === x && p.y === y);
+        const isFood = food.x === x && food.y === y;
+        const bg = isFood ? 'bg-red-500' : isSnake ? 'bg-green-600' : 'bg-gray-200';
+        return <div key={i} className={`w-3 h-3 ${bg}`}></div>;
+      })}
+    </div>
+  );
+};
+
+export default SnakeGame;


### PR DESCRIPTION
## Summary
- add a small Snake game component
- show the Snake game while loading comparisons
- enhance precise specs dialog with multiple device support and skip option
- wire new dialog props through comparison forms and hooks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686faf19b60083308078069d8bf17fe1