### PR TITLE
Improve comparison table styling

### DIFF
--- a/src/components/ComparisonResult.tsx
+++ b/src/components/ComparisonResult.tsx
@@ -193,37 +193,37 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
         ) : (
           <>
             {/* Comparaison des spécifications */}
-            <Card className="bg-white/80 backdrop-blur-sm border-tech-gray-200 shadow-card">
+            <Card className="bg-white/80 backdrop-blur-sm border border-tech-gray-200 shadow-soft">
               <CardContent className="p-8">
                 <h3 className="text-xl font-bold text-tech-dark mb-6">Technical Comparison</h3>
                 <div className="overflow-x-auto">
-                  <Table className="space-y-4">
+                  <Table className="w-full text-sm">
                     <TableHeader>
-                      <TableRow className="bg-tech-gray-100 rounded-xl font-semibold text-tech-dark text-sm">
-                        <TableHead scope="col" className="px-4 py-3">Component</TableHead>
-                        <TableHead scope="col" className="px-4 py-3 text-center">{data.currentDevice}</TableHead>
-                        <TableHead scope="col" className="px-4 py-3 text-center">Impact</TableHead>
-                        <TableHead scope="col" className="px-4 py-3 text-center">{data.newDevice}</TableHead>
-                        <TableHead scope="col" className="px-4 py-3 text-center">Why Better?</TableHead>
+                      <TableRow className="bg-tech-gray-100 text-tech-dark">
+                        <TableHead scope="col" className="px-6 py-3 font-bold">Component</TableHead>
+                        <TableHead scope="col" className="px-6 py-3 text-center font-bold">{data.currentDevice}</TableHead>
+                        <TableHead scope="col" className="px-6 py-3 text-center font-bold">Impact</TableHead>
+                        <TableHead scope="col" className="px-6 py-3 text-center font-bold">{data.newDevice}</TableHead>
+                        <TableHead scope="col" className="px-6 py-3 text-center font-bold">Why Better?</TableHead>
                       </TableRow>
                     </TableHeader>
-                    <TableBody className="space-y-4">
+                    <TableBody className="divide-y divide-tech-gray-200">
                       {data.specs.map((spec, index) => (
                         <React.Fragment key={index}>
-                          <TableRow className="bg-tech-gray-50 rounded-xl">
-                            <TableCell className="px-4 py-4 font-semibold text-tech-dark">
+                          <TableRow className="odd:bg-white even:bg-tech-gray-50">
+                            <TableCell className="px-6 py-3 font-semibold text-tech-dark">
                               {spec.category}
                             </TableCell>
-                            <TableCell className="px-4 py-4 text-center text-tech-gray-600">
+                            <TableCell className="px-6 py-3 text-center text-tech-gray-600">
                               {spec.current}
                             </TableCell>
-                            <TableCell className="px-4 py-4 text-center">
+                            <TableCell className="px-6 py-3 text-center">
                               {getImprovementIcon(spec.improvement)}
                             </TableCell>
-                            <TableCell className="px-4 py-4 text-center font-semibold text-tech-dark">
+                            <TableCell className="px-6 py-3 text-center font-semibold text-tech-dark">
                               {spec.new}
                             </TableCell>
-                            <TableCell className="px-4 py-4 text-center">
+                            <TableCell className="px-6 py-3 text-center">
                               <span className="text-xs text-tech-gray-600 font-medium">
                                 {getBriefExplanation(spec.category, spec.improvement)}
                               </span>
@@ -233,7 +233,7 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
                             <TableRow>
                               <TableCell
                                 colSpan={5}
-                                className="border-t border-tech-gray-200 px-4 pt-2 pb-4 text-tech-gray-700 text-sm"
+                                className="border-t border-tech-gray-200 px-6 pt-2 pb-4 text-tech-gray-700 text-sm"
                               >
                                 {data.reasons[index]}
                               </TableCell>
@@ -242,14 +242,14 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
                         </React.Fragment>
                       ))}
                       {data.reasons.slice(data.specs.length).map((reason, index) => (
-                        <TableRow key={`extra-${index}`}>
-                          <TableCell
-                            colSpan={5}
-                            className="p-4 bg-tech-gray-50 rounded-xl text-tech-gray-700 text-sm"
-                          >
-                            {reason}
-                          </TableCell>
-                        </TableRow>
+                          <TableRow key={`extra-${index}`}>
+                            <TableCell
+                              colSpan={5}
+                              className="px-6 py-3 bg-tech-gray-50 text-tech-gray-700 text-sm"
+                            >
+                              {reason}
+                            </TableCell>
+                          </TableRow>
                       ))}
                     </TableBody>
                   </Table>


### PR DESCRIPTION
## Summary
- refine styling for the semantic comparison table
- keep other table views intact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fe057fd0483309b848e3be53e1e00