### PR TITLE
Bypass empty cache entries

### DIFF
--- a/src/hooks/useMockData.ts
+++ b/src/hooks/useMockData.ts
@@ -75,7 +75,7 @@ export const useMockData = () => {
       const cacheKey = `${currentDevice}|${newDevice}`;
       const cachedResult = cacheService.get('COMPARISON', cacheKey);
 
-      if (cachedResult) {
+      if (cachedResult && Array.isArray(cachedResult.technicalSpecs) && cachedResult.technicalSpecs.length > 0) {
         console.log('Using cached comparison data');
         setIsLoading(false);
         return cachedResult;


### PR DESCRIPTION
## Summary
- check cached `technicalSpecs` entries when using `useMockData`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68700540c0bc833082b0820a1f2281cb