### PR TITLE
Add structured sections to comparison output

### DIFF
--- a/src/components/ComparisonResult.tsx
+++ b/src/components/ComparisonResult.tsx
@@ -20,14 +20,8 @@ interface ComparisonData {
   newDevice: string;
   recommendation: 'upgrade' | 'keep' | 'maybe';
   score: number;
-  reasons: string[];
-  specs: {
-    category: string;
-    current: string;
-    new: string;
-    improvement: 'better' | 'worse' | 'same';
-  }[];
-  technicalSpecs: {
+  takeHome: string;
+  connoisseurSpecs: {
     category: string;
     subcategory?: string;
     current: {
@@ -185,78 +179,18 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
 
         {/* Conditional View */}
         {isConnoisseurView ? (
-          <TechnicalView 
+          <TechnicalView
             currentDevice={data.currentDevice}
             newDevice={data.newDevice}
-            specs={data.technicalSpecs}
+            specs={data.connoisseurSpecs}
           />
         ) : (
-          <>
-            {/* Comparaison des spécifications */}
-            <Card className="bg-white/80 backdrop-blur-sm border border-tech-gray-200 shadow-soft">
-              <CardContent className="p-8">
-                <h3 className="text-xl font-bold text-tech-dark mb-6">Technical Comparison</h3>
-                <div className="overflow-x-auto">
-                  <Table className="w-full text-sm">
-                    <TableHeader>
-                      <TableRow className="bg-tech-gray-100 text-tech-dark">
-                        <TableHead scope="col" className="px-6 py-3 font-bold">Component</TableHead>
-                        <TableHead scope="col" className="px-6 py-3 text-center font-bold">{data.currentDevice}</TableHead>
-                        <TableHead scope="col" className="px-6 py-3 text-center font-bold">Impact</TableHead>
-                        <TableHead scope="col" className="px-6 py-3 text-center font-bold">{data.newDevice}</TableHead>
-                        <TableHead scope="col" className="px-6 py-3 text-center font-bold">Why Better?</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody className="divide-y divide-tech-gray-200">
-                      {data.specs.map((spec, index) => (
-                        <React.Fragment key={index}>
-                          <TableRow className="odd:bg-white even:bg-tech-gray-50">
-                            <TableCell className="px-6 py-3 font-semibold text-tech-dark">
-                              {spec.category}
-                            </TableCell>
-                            <TableCell className="px-6 py-3 text-center text-tech-gray-600">
-                              {spec.current}
-                            </TableCell>
-                            <TableCell className="px-6 py-3 text-center">
-                              {getImprovementIcon(spec.improvement)}
-                            </TableCell>
-                            <TableCell className="px-6 py-3 text-center font-semibold text-tech-dark">
-                              {spec.new}
-                            </TableCell>
-                            <TableCell className="px-6 py-3 text-center">
-                              <span className="text-xs text-tech-gray-600 font-medium">
-                                {getBriefExplanation(spec.category, spec.improvement)}
-                              </span>
-                            </TableCell>
-                          </TableRow>
-                          {data.reasons[index] && (
-                            <TableRow>
-                              <TableCell
-                                colSpan={5}
-                                className="border-t border-tech-gray-200 px-6 pt-2 pb-4 text-tech-gray-700 text-sm"
-                              >
-                                {data.reasons[index]}
-                              </TableCell>
-                            </TableRow>
-                          )}
-                        </React.Fragment>
-                      ))}
-                      {data.reasons.slice(data.specs.length).map((reason, index) => (
-                          <TableRow key={`extra-${index}`}>
-                            <TableCell
-                              colSpan={5}
-                              className="px-6 py-3 bg-tech-gray-50 text-tech-gray-700 text-sm"
-                            >
-                              {reason}
-                            </TableCell>
-                          </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
-              </CardContent>
-            </Card>
-          </>
+          <Card className="bg-white/80 backdrop-blur-sm border border-tech-gray-200 shadow-soft">
+            <CardContent className="p-8">
+              <h3 className="text-xl font-bold text-tech-dark mb-6">Take Home Summary</h3>
+              <p className="text-tech-gray-700 whitespace-pre-line">{data.takeHome}</p>
+            </CardContent>
+          </Card>
         )}
 
         {/* Bouton pour recommencer */}

--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -19,14 +19,8 @@ interface ComparisonData {
   newDevice: string;
   recommendation: 'upgrade' | 'keep' | 'maybe';
   score: number;
-  reasons: string[];
-  specs: {
-    category: string;
-    current: string;
-    new: string;
-    improvement: 'better' | 'worse' | 'same';
-  }[];
-  technicalSpecs: {
+  takeHome: string;
+  connoisseurSpecs: {
     category: string;
     subcategory?: string;
     current: {

--- a/src/hooks/useMockData.ts
+++ b/src/hooks/useMockData.ts
@@ -10,14 +10,8 @@ interface ComparisonData {
   newDevice: string;
   recommendation: 'upgrade' | 'keep' | 'maybe';
   score: number;
-  reasons: string[];
-  specs: {
-    category: string;
-    current: string;
-    new: string;
-    improvement: 'better' | 'worse' | 'same';
-  }[];
-  technicalSpecs: {
+  takeHome: string;
+  connoisseurSpecs: {
     category: string;
     subcategory?: string;
     current: {
@@ -75,7 +69,7 @@ export const useMockData = () => {
       const cacheKey = `${currentDevice}|${newDevice}`;
       const cachedResult = cacheService.get('COMPARISON', cacheKey);
 
-      if (cachedResult && Array.isArray(cachedResult.technicalSpecs) && cachedResult.technicalSpecs.length > 0) {
+      if (cachedResult && Array.isArray(cachedResult.connoisseurSpecs) && cachedResult.connoisseurSpecs.length > 0) {
         console.log('Using cached comparison data');
         setIsLoading(false);
         return cachedResult;

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -150,19 +150,18 @@ class GeminiServiceClass {
   async getProductComparison(currentDevice: string, newDevice: string): Promise<any> {
     const safeCurrent = sanitizeInput(currentDevice);
     const safeNew = sanitizeInput(newDevice);
-    const prompt = `Compare these two devices and provide a detailed analysis:
+    const prompt = `Compare these two devices:
 
 Current device: ${safeCurrent}
 New device: ${safeNew}
 
-Please respond with a JSON object containing:
+Return a JSON object with:
 - recommendation: "upgrade" | "keep" | "maybe"
 - score: number (0-100)
-- reasons: array of strings explaining the recommendation
-- specs: array of comparison specs with category, current, new, and improvement
-- technicalSpecs: detailed technical comparison
+- takeHome: short summary of the key points
+- connoisseurSpecs: detailed technical comparison with category, current value, new value, improvement, score and details
 
-Focus on performance, features, value, and user experience. Be objective and helpful.`;
+Focus on performance, features, value and user experience. Only output valid JSON.`;
 
     const response = await this.callGeminiAPI(prompt);
     try {

--- a/src/utils/specCheck.ts
+++ b/src/utils/specCheck.ts
@@ -1,12 +1,10 @@
 export const MIN_SPEC_COUNT = 3;
 
 export interface SpecData {
-  specs?: unknown[];
-  technicalSpecs?: unknown[];
+  connoisseurSpecs?: unknown[];
 }
 
 export function needsPreciseSpecs(data: SpecData, min: number = MIN_SPEC_COUNT): boolean {
-  const specCount = data.specs?.length ?? 0;
-  const techCount = data.technicalSpecs?.length ?? 0;
-  return specCount < min || techCount < min;
+  const count = data.connoisseurSpecs?.length ?? 0;
+  return count < min;
 }

--- a/tests/ComparisonResult.test.tsx
+++ b/tests/ComparisonResult.test.tsx
@@ -10,11 +10,8 @@ const mockData = {
   newDevice: 'Device B',
   recommendation: 'upgrade' as const,
   score: 90,
-  reasons: ['Better performance'],
-  specs: [
-    { category: 'processor', current: 'A1', new: 'B1', improvement: 'better' as const }
-  ],
-  technicalSpecs: [
+  takeHome: 'Better performance overall',
+  connoisseurSpecs: [
     {
       category: 'CPU',
       current: { value: 'A1', technical: 'specA' },
@@ -36,12 +33,8 @@ describe('ComparisonResult', () => {
     expect(screen.queryByText('Detailed Technical Analysis')).toBeNull();
   });
 
-  it('renders comparison table headers with device names', () => {
+  it('renders summary in default view', () => {
     render(<ComparisonResult data={mockData} onReset={() => {}} />);
-    expect(screen.getByRole('columnheader', { name: /component/i })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /device a/i })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /impact/i })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /device b/i })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /why better/i })).toBeInTheDocument();
+    expect(screen.getByText(/Better performance overall/i)).toBeInTheDocument();
   });
 });

--- a/tests/specCheck.test.ts
+++ b/tests/specCheck.test.ts
@@ -3,16 +3,16 @@ import { needsPreciseSpecs } from '../src/utils/specCheck';
 
 describe('needsPreciseSpecs', () => {
   it('returns true when arrays are empty', () => {
-    expect(needsPreciseSpecs({ specs: [], technicalSpecs: [] })).toBe(true);
+    expect(needsPreciseSpecs({ connoisseurSpecs: [] })).toBe(true);
   });
 
   it('returns true when below threshold', () => {
-    expect(needsPreciseSpecs({ specs: ['a'], technicalSpecs: ['b'] })).toBe(true);
+    expect(needsPreciseSpecs({ connoisseurSpecs: ['a'] })).toBe(true);
   });
 
   it('returns false when enough data', () => {
     expect(
-      needsPreciseSpecs({ specs: [1, 2, 3], technicalSpecs: [1, 2, 3] })
+      needsPreciseSpecs({ connoisseurSpecs: [1, 2, 3] })
     ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- request `takeHome` and `connoisseurSpecs` in comparison prompt
- parse `connoisseurSpecs` in spec checker and hook interfaces
- show `takeHome` summary by default and detailed view with `connoisseurSpecs`
- update tests for new structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68700dc32ed88330953fb37b5fcba030