### PR TITLE
Add reason parsing helper

### DIFF
--- a/src/components/ComparisonResult.tsx
+++ b/src/components/ComparisonResult.tsx
@@ -14,12 +14,14 @@ import { CheckCircle, XCircle, AlertTriangle, ShoppingCart } from 'lucide-react'
 import TechnicalView from './TechnicalView';
 import MultiCompareButton from './MultiCompareButton';
 import MultiCompare from './MultiCompare';
+import { extractReasonCategory } from '@/utils/reasons';
 
 interface ComparisonData {
   currentDevice: string;
   newDevice: string;
   recommendation: 'upgrade' | 'keep' | 'maybe';
   score: number;
+  reasons?: string[];
   takeHome: string;
   connoisseurSpecs: {
     category: string;
@@ -185,12 +187,36 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
             specs={data.connoisseurSpecs}
           />
         ) : (
-          <Card className="bg-white/80 backdrop-blur-sm border border-tech-gray-200 shadow-soft">
-            <CardContent className="p-8">
-              <h3 className="text-xl font-bold text-tech-dark mb-6">Take Home Summary</h3>
-              <p className="text-tech-gray-700 whitespace-pre-line">{data.takeHome}</p>
-            </CardContent>
-          </Card>
+          <>
+            <Card className="bg-white/80 backdrop-blur-sm border border-tech-gray-200 shadow-soft">
+              <CardContent className="p-8">
+                <h3 className="text-xl font-bold text-tech-dark mb-6">Take Home Summary</h3>
+                <p className="text-tech-gray-700 whitespace-pre-line">{data.takeHome}</p>
+              </CardContent>
+            </Card>
+            {data.reasons && data.reasons.length > 0 && (
+              <Card className="bg-white/80 backdrop-blur-sm border border-tech-gray-200 shadow-soft">
+                <CardContent className="p-8">
+                  <h3 className="text-xl font-bold text-tech-dark mb-6">Key Reasons</h3>
+                  <Table>
+                    <TableBody>
+                      {data.reasons.map((reason, index) => {
+                        const { title, description } = extractReasonCategory(reason);
+                        return (
+                          <TableRow key={index}>
+                            <TableHead scope="row" className="w-40 font-semibold text-tech-dark">
+                              {title || `Reason ${index + 1}`}
+                            </TableHead>
+                            <TableCell className="text-tech-gray-700">{description}</TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+            )}
+          </>
         )}
 
         {/* Bouton pour recommencer */}

--- a/src/utils/reasons.ts
+++ b/src/utils/reasons.ts
@@ -1,0 +1,17 @@
+export interface ReasonParts {
+  title: string | null;
+  description: string;
+}
+
+/**
+ * Extracts a title and description from a reason string formatted as
+ * "**Title:** Description". If the pattern isn't found, the entire string is
+ * returned as the description and title will be null.
+ */
+export function extractReasonCategory(reason: string): ReasonParts {
+  const match = reason.match(/\*\*(.+?):\*\*\s*(.+)/);
+  if (match) {
+    return { title: match[1].trim(), description: match[2].trim() };
+  }
+  return { title: null, description: reason.trim() };
+}

--- a/tests/ComparisonResult.test.tsx
+++ b/tests/ComparisonResult.test.tsx
@@ -10,6 +10,7 @@ const mockData = {
   newDevice: 'Device B',
   recommendation: 'upgrade' as const,
   score: 90,
+  reasons: ['**Performance:** Faster', '**Battery:** Lasts longer'],
   takeHome: 'Better performance overall',
   connoisseurSpecs: [
     {
@@ -36,5 +37,13 @@ describe('ComparisonResult', () => {
   it('renders summary in default view', () => {
     render(<ComparisonResult data={mockData} onReset={() => {}} />);
     expect(screen.getByText(/Better performance overall/i)).toBeInTheDocument();
+  });
+
+  it('parses reason titles and descriptions', () => {
+    render(<ComparisonResult data={mockData} onReset={() => {}} />);
+    expect(screen.getByRole('rowheader', { name: /Performance/i })).toBeInTheDocument();
+    expect(screen.getByText('Faster')).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: /Battery/i })).toBeInTheDocument();
+    expect(screen.getByText('Lasts longer')).toBeInTheDocument();
   });
 });

--- a/tests/reasons.test.ts
+++ b/tests/reasons.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { extractReasonCategory } from '../src/utils/reasons';
+
+describe('extractReasonCategory', () => {
+  it('splits reason with markdown title', () => {
+    const result = extractReasonCategory('**Performance:** Much faster.');
+    expect(result).toEqual({ title: 'Performance', description: 'Much faster.' });
+  });
+
+  it('returns original string when pattern missing', () => {
+    const result = extractReasonCategory('No special format');
+    expect(result).toEqual({ title: null, description: 'No special format' });
+  });
+});


### PR DESCRIPTION
## Summary
- parse reason strings with `extractReasonCategory`
- show key reasons in `ComparisonResult`
- test new parsing utility and render logic

## Testing
- `npx vitest --run`

------
https://chatgpt.com/codex/tasks/task_e_6870123d71f48330a35eec0412a7a983