### PR TITLE
Add spec summary table

### DIFF
--- a/src/components/ComparisonResult.tsx
+++ b/src/components/ComparisonResult.tsx
@@ -194,6 +194,46 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
                 <p className="text-tech-gray-700 whitespace-pre-line">{data.takeHome}</p>
               </CardContent>
             </Card>
+            {data.connoisseurSpecs && data.connoisseurSpecs.length > 0 && (
+              <Card className="bg-white/80 backdrop-blur-sm border border-tech-gray-200 shadow-soft">
+                <CardContent className="p-8">
+                  <h3 className="text-xl font-bold text-tech-dark mb-6">Quick Spec Comparison</h3>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="font-bold text-tech-dark">Component</TableHead>
+                        <TableHead className="font-bold text-tech-dark text-center">{data.currentDevice}</TableHead>
+                        <TableHead className="font-bold text-tech-dark text-center">Impact</TableHead>
+                        <TableHead className="font-bold text-tech-dark text-center">{data.newDevice}</TableHead>
+                        <TableHead className="font-bold text-tech-dark text-center">Why Better?</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {data.connoisseurSpecs.map((spec, index) => (
+                        <TableRow key={index} className="hover:bg-tech-gray-50/50">
+                          <TableHead scope="row" className="font-semibold text-tech-dark">
+                            <div>
+                              {spec.category}
+                              {spec.subcategory && (
+                                <div className="text-sm text-tech-gray-600 font-normal">{spec.subcategory}</div>
+                              )}
+                            </div>
+                          </TableHead>
+                          <TableCell className="text-center text-tech-gray-700">{spec.current.value}</TableCell>
+                          <TableCell className="text-center">{getImprovementIcon(spec.improvement)}</TableCell>
+                          <TableCell className="text-center font-semibold text-tech-dark">{spec.new.value}</TableCell>
+                          <TableCell className="text-center">
+                            <span className="text-xs text-tech-gray-600 font-medium">
+                              {getBriefExplanation(spec.category, spec.improvement)}
+                            </span>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+            )}
             {data.reasons && data.reasons.length > 0 && (
               <Card className="bg-white/80 backdrop-blur-sm border border-tech-gray-200 shadow-soft">
                 <CardContent className="p-8">

--- a/tests/ComparisonResult.test.tsx
+++ b/tests/ComparisonResult.test.tsx
@@ -39,6 +39,21 @@ describe('ComparisonResult', () => {
     expect(screen.getByText(/Better performance overall/i)).toBeInTheDocument();
   });
 
+  it('renders spec table by default and hides it when toggled', async () => {
+    render(<ComparisonResult data={mockData} onReset={() => {}} />);
+    expect(screen.getByRole('rowheader', { name: /CPU/i })).toBeInTheDocument();
+    expect(screen.getByText('A1')).toBeInTheDocument();
+    expect(screen.getByText('B1')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('switch'));
+    expect(
+      screen.queryByRole('heading', { name: /Quick Spec Comparison/i })
+    ).toBeNull();
+    await userEvent.click(screen.getByRole('switch'));
+    expect(
+      screen.getByRole('heading', { name: /Quick Spec Comparison/i })
+    ).toBeInTheDocument();
+  });
+
   it('parses reason titles and descriptions', () => {
     render(<ComparisonResult data={mockData} onReset={() => {}} />);
     expect(screen.getByRole('rowheader', { name: /Performance/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- show a short spec comparison table in `ComparisonResult`
- test that the table shows in default view and hides when toggled

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6870bc1e55a88330a728f8aafac03f43