### PR TITLE
Normalize spec data for gemini results

### DIFF
--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -2,6 +2,7 @@
 import { sanitizeInput } from '@/utils/sanitize';
 import { parseGeminiResponse } from '@/utils/parseGeminiResponse';
 import { GeminiParseError, GeminiTokenLimitError } from '@/utils/geminiErrors';
+import { normalizeConnoisseurSpecs } from './specNormalizer';
 
 interface GeminiRequest {
   currentDevice: string;
@@ -165,7 +166,11 @@ Focus on performance, features, value and user experience. Only output valid JSO
 
     const response = await this.callGeminiAPI(prompt);
     try {
-      return parseGeminiResponse(response);
+      const result = parseGeminiResponse(response);
+      if (result && typeof result === 'object') {
+        result.connoisseurSpecs = normalizeConnoisseurSpecs(result.connoisseurSpecs);
+      }
+      return result;
     } catch (error) {
       console.error('Failed to parse Gemini response', { prompt, response });
       if (error instanceof GeminiParseError || error instanceof GeminiTokenLimitError) {

--- a/src/services/specNormalizer.ts
+++ b/src/services/specNormalizer.ts
@@ -1,0 +1,46 @@
+export interface RawSpecItem {
+  category: string;
+  subcategory?: string;
+  currentValue?: string;
+  currentTechnical?: string;
+  newValue?: string;
+  newTechnical?: string;
+  improvement?: 'better' | 'worse' | 'same';
+  score?: number;
+  details?: string;
+  // allow unknown extra fields
+  [key: string]: any;
+}
+
+export interface NormalizedSpecItem {
+  category: string;
+  subcategory?: string;
+  current: { value: string; technical: string };
+  new: { value: string; technical: string };
+  improvement: 'better' | 'worse' | 'same';
+  score: number;
+  details: string;
+}
+
+export function normalizeConnoisseurSpecs(specs: RawSpecItem[] | undefined): NormalizedSpecItem[] {
+  if (!Array.isArray(specs)) return [];
+  return specs.map((item) => {
+    const current = {
+      value: item.current?.value ?? item.currentValue ?? '',
+      technical: item.current?.technical ?? item.currentTechnical ?? ''
+    };
+    const newData = {
+      value: item.new?.value ?? item.newValue ?? '',
+      technical: item.new?.technical ?? item.newTechnical ?? ''
+    };
+    return {
+      category: item.category,
+      subcategory: item.subcategory,
+      current,
+      new: newData,
+      improvement: item.improvement ?? 'same',
+      score: item.score ?? 0,
+      details: item.details ?? ''
+    };
+  });
+}

--- a/tests/ComparisonResult.test.tsx
+++ b/tests/ComparisonResult.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import ComparisonResult from '../src/components/ComparisonResult';
+import { normalizeConnoisseurSpecs } from '../src/services/specNormalizer';
 
 const mockData = {
   currentDevice: 'Device A',
@@ -15,8 +16,10 @@ const mockData = {
   connoisseurSpecs: [
     {
       category: 'CPU',
-      current: { value: 'A1', technical: 'specA' },
-      new: { value: 'B1', technical: 'specB' },
+      currentValue: 'A1',
+      currentTechnical: 'specA',
+      newValue: 'B1',
+      newTechnical: 'specB',
       improvement: 'better' as const,
       score: 95,
       details: 'Faster'
@@ -24,9 +27,14 @@ const mockData = {
   ]
 };
 
+const normalizedData = {
+  ...mockData,
+  connoisseurSpecs: normalizeConnoisseurSpecs(mockData.connoisseurSpecs)
+};
+
 describe('ComparisonResult', () => {
   it('shows TechnicalView when switch is toggled', async () => {
-    render(<ComparisonResult data={mockData} onReset={() => {}} />);
+    render(<ComparisonResult data={normalizedData} onReset={() => {}} />);
     expect(screen.queryByText('Detailed Technical Analysis')).toBeNull();
     await userEvent.click(screen.getByRole('switch'));
     expect(screen.getByText('Detailed Technical Analysis')).toBeInTheDocument();
@@ -35,12 +43,12 @@ describe('ComparisonResult', () => {
   });
 
   it('renders summary in default view', () => {
-    render(<ComparisonResult data={mockData} onReset={() => {}} />);
+    render(<ComparisonResult data={normalizedData} onReset={() => {}} />);
     expect(screen.getByText(/Better performance overall/i)).toBeInTheDocument();
   });
 
   it('renders spec table by default and hides it when toggled', async () => {
-    render(<ComparisonResult data={mockData} onReset={() => {}} />);
+    render(<ComparisonResult data={normalizedData} onReset={() => {}} />);
     expect(screen.getByRole('rowheader', { name: /CPU/i })).toBeInTheDocument();
     expect(screen.getByText('A1')).toBeInTheDocument();
     expect(screen.getByText('B1')).toBeInTheDocument();
@@ -55,7 +63,7 @@ describe('ComparisonResult', () => {
   });
 
   it('parses reason titles and descriptions', () => {
-    render(<ComparisonResult data={mockData} onReset={() => {}} />);
+    render(<ComparisonResult data={normalizedData} onReset={() => {}} />);
     expect(screen.getByRole('rowheader', { name: /Performance/i })).toBeInTheDocument();
     expect(screen.getByText('Faster')).toBeInTheDocument();
     expect(screen.getByRole('rowheader', { name: /Battery/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add `normalizeConnoisseurSpecs` utility
- normalize connoisseur specs in `getProductComparison`
- update component tests to use raw spec fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68755711f3648330ae32b374ebea27ca