### PR TITLE
Implement detail completeness check before comparisons

### DIFF
--- a/src/components/ComparisonDialogs.tsx
+++ b/src/components/ComparisonDialogs.tsx
@@ -15,6 +15,7 @@ interface ComparisonDialogsProps {
   onPreciseSpecsSubmit: (specs: any) => void;
   onSkipPreciseSpecs: () => void;
   isPaidUser?: boolean;
+  preciseDevice: string;
 }
 
 const ComparisonDialogs = ({
@@ -27,7 +28,8 @@ const ComparisonDialogs = ({
   setShowPreciseSpecs,
   onPreciseSpecsSubmit,
   onSkipPreciseSpecs,
-  isPaidUser
+  isPaidUser,
+  preciseDevice
 }: ComparisonDialogsProps) => {
   return (
     <>
@@ -48,6 +50,7 @@ const ComparisonDialogs = ({
         onSubmit={onPreciseSpecsSubmit}
         onSkip={onSkipPreciseSpecs}
         isPaidUser={isPaidUser}
+        device={preciseDevice}
       />
     </>
   );

--- a/src/components/ComparisonForm.tsx
+++ b/src/components/ComparisonForm.tsx
@@ -89,6 +89,7 @@ const ComparisonForm = () => {
         onPreciseSpecsSubmit={handlePreciseSpecsSubmit}
         onSkipPreciseSpecs={handleSkipPreciseSpecs}
         isPaidUser={false}
+        preciseDevice={preciseDevice}
       />
     </>
   );

--- a/src/components/PreciseSpecsDialog.tsx
+++ b/src/components/PreciseSpecsDialog.tsx
@@ -13,6 +13,7 @@ interface PreciseSpecsDialogProps {
   onSubmit: (specs: PreciseSpecs[]) => void;
   onSkip: () => void;
   isPaidUser?: boolean;
+  device?: string;
 }
 
 interface PreciseSpecs {
@@ -33,7 +34,7 @@ const emptySpecs: PreciseSpecs = {
   additionalSpecs: ''
 };
 
-const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit, onSkip, isPaidUser = false }: PreciseSpecsDialogProps) => {
+const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit, onSkip, isPaidUser = false, device }: PreciseSpecsDialogProps) => {
   const [specsList, setSpecsList] = useState<PreciseSpecs[]>([ { ...emptySpecs } ]);
 
   const addDevice = () => {
@@ -74,6 +75,11 @@ const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit, onSkip, isPaidUser = fa
         <DialogDescription id="precise-specs-desc">
           Provide detailed hardware specifications for a more accurate comparison.
         </DialogDescription>
+        {device && (
+          <p className="text-sm text-gray-600 mt-2">
+            More details are needed for <span className="font-semibold">{device}</span>.
+          </p>
+        )}
         
         <form onSubmit={handleSubmit} className="space-y-6">
           {specsList.map((specs, idx) => (

--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -83,6 +83,37 @@ export const useComparisonForm = () => {
       
       // Proceed directly to comparison
       try {
+        const compatibility = await geminiService.checkComparability(
+          currentProduct,
+          newProduct
+        );
+
+        if (!compatibility.comparable) {
+          setComparisonResult({
+            isIncompatible: true,
+            currentDevice: currentProduct,
+            newDevice: newProduct,
+            explanation: `I cannot compare "${currentProduct}" and "${newProduct}" because they belong to different categories (${compatibility.category1} vs ${compatibility.category2}).`
+          });
+          return;
+        }
+
+        const completeness = await geminiService.checkDetailCompleteness(
+          currentProduct,
+          newProduct
+        );
+
+        if (!completeness.current.complete || !completeness.new.complete) {
+          const deviceInfo = !completeness.current.complete && !completeness.new.complete
+            ? `${currentProduct} and ${newProduct}`
+            : !completeness.current.complete
+              ? currentProduct
+              : newProduct;
+          setPreciseDevice(deviceInfo);
+          setShowPreciseSpecs(true);
+          return;
+        }
+
         const result = await simulateAnalysis(currentProduct, newProduct);
         if (!('isIncompatible' in result) && needsPreciseSpecs(result)) {
           setPendingComparison(result);

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -168,6 +168,29 @@ class GeminiServiceClass {
     }
   }
 
+  async checkDetailCompleteness(
+    currentDevice: string,
+    newDevice: string
+  ): Promise<{
+    current: { complete: boolean; missing: string[] };
+    new: { complete: boolean; missing: string[] };
+  }> {
+    const safeCurrent = sanitizeInput(currentDevice);
+    const safeNew = sanitizeInput(newDevice);
+    const prompt = `For each of the following product descriptions, tell me if it contains enough detail to uniquely identify the model (like model number or release year). List any missing elements.\n\nCurrent: ${safeCurrent}\nNew: ${safeNew}\n\nReturn only JSON in this format:\n{ "current": { "complete": boolean, "missing": string[] }, "new": { "complete": boolean, "missing": string[] } }`;
+
+    const response = await this.callGeminiAPI(prompt);
+    try {
+      return parseGeminiResponse(response);
+    } catch (error) {
+      console.error('Failed to parse Gemini response', { prompt, response });
+      if (error instanceof GeminiParseError || error instanceof GeminiTokenLimitError) {
+        throw error;
+      }
+      throw new GeminiParseError('Unexpected Gemini response');
+    }
+  }
+
   async getProductComparison(currentDevice: string, newDevice: string): Promise<any> {
     const safeCurrent = sanitizeInput(currentDevice);
     const safeNew = sanitizeInput(newDevice);

--- a/tests/PreciseSpecsDialog.test.tsx
+++ b/tests/PreciseSpecsDialog.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PreciseSpecsDialog from '../src/components/PreciseSpecsDialog';
+
+
+describe('PreciseSpecsDialog', () => {
+  it('shows device information when provided', () => {
+    render(
+      <PreciseSpecsDialog
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onSkip={() => {}}
+        device="MacBook Pro"
+      />
+    );
+    expect(screen.getByText(/More details are needed for/i)).toHaveTextContent('MacBook Pro');
+  });
+});


### PR DESCRIPTION
## Summary
- extend `geminiService` with `checkDetailCompleteness`
- show which device lacks info in `PreciseSpecsDialog`
- plumb `preciseDevice` prop through `ComparisonDialogs` and `ComparisonForm`
- trigger completeness check in `useComparisonForm` before requesting comparison
- add regression test for dialog message

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6875773516a88330bbd713336917811b