### PR TITLE
Fix preciseDevice extraction in ComparisonForm

### DIFF
--- a/src/components/ComparisonForm.tsx
+++ b/src/components/ComparisonForm.tsx
@@ -21,6 +21,7 @@ const ComparisonForm = () => {
     showQueue,
     showPreciseSpecs,
     notFoundProduct,
+    preciseDevice,
     isLoading,
     setShowProductNotFound,
     setShowQueue,


### PR DESCRIPTION
## Summary
- destructure `preciseDevice` from `useComparisonForm`
- keep `preciseDevice` prop when rendering `<ComparisonDialogs>`

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875e75555788330b5cced4452b13e95