### PR TITLE
Add category support for precise specs dialog

### DIFF
--- a/src/components/ComparisonDialogs.tsx
+++ b/src/components/ComparisonDialogs.tsx
@@ -16,6 +16,7 @@ interface ComparisonDialogsProps {
   onSkipPreciseSpecs: () => void;
   isPaidUser?: boolean;
   preciseDevice: string;
+  category: string;
 }
 
 const ComparisonDialogs = ({
@@ -29,7 +30,8 @@ const ComparisonDialogs = ({
   onPreciseSpecsSubmit,
   onSkipPreciseSpecs,
   isPaidUser,
-  preciseDevice
+  preciseDevice,
+  category
 }: ComparisonDialogsProps) => {
   return (
     <>
@@ -51,6 +53,7 @@ const ComparisonDialogs = ({
         onSkip={onSkipPreciseSpecs}
         isPaidUser={isPaidUser}
         device={preciseDevice}
+        category={category}
       />
     </>
   );

--- a/src/components/ComparisonForm.tsx
+++ b/src/components/ComparisonForm.tsx
@@ -22,6 +22,7 @@ const ComparisonForm = () => {
     showPreciseSpecs,
     notFoundProduct,
     preciseDevice,
+    category,
     isLoading,
     setShowProductNotFound,
     setShowQueue,
@@ -91,6 +92,7 @@ const ComparisonForm = () => {
         onSkipPreciseSpecs={handleSkipPreciseSpecs}
         isPaidUser={false}
         preciseDevice={preciseDevice}
+        category={category}
       />
     </>
   );

--- a/src/components/PreciseSpecsDialog.tsx
+++ b/src/components/PreciseSpecsDialog.tsx
@@ -1,11 +1,97 @@
 
 import React, { useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription
+} from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { Settings, Cpu, HardDrive, Monitor, Battery } from 'lucide-react';
+import {
+  Settings,
+  Cpu,
+  HardDrive,
+  Monitor,
+  Battery,
+  Car
+} from 'lucide-react';
+
+interface FieldDef {
+  key: string;
+  label: string;
+  placeholder?: string;
+  icon?: React.ReactNode;
+  textarea?: boolean;
+}
+
+const FIELD_SETS: Record<string, FieldDef[]> = {
+  computer: [
+    {
+      key: 'processor',
+      label: 'Processor',
+      placeholder: 'e.g., Apple M3, Intel Core i7-13700H',
+      icon: <Cpu className="h-4 w-4 text-blue-600" />
+    },
+    {
+      key: 'ram',
+      label: 'RAM',
+      placeholder: 'e.g., 16GB LPDDR5, 32GB DDR4',
+      icon: <HardDrive className="h-4 w-4 text-green-600" />
+    },
+    {
+      key: 'storage',
+      label: 'Storage',
+      placeholder: 'e.g., 512GB SSD, 1TB NVMe',
+      icon: <HardDrive className="h-4 w-4 text-purple-600" />
+    },
+    {
+      key: 'display',
+      label: 'Display',
+      placeholder: 'e.g., 13.6" Liquid Retina, 15.6" OLED 4K',
+      icon: <Monitor className="h-4 w-4 text-orange-600" />
+    },
+    {
+      key: 'battery',
+      label: 'Battery Life',
+      placeholder: 'e.g., 18 hours, 5000mAh',
+      icon: <Battery className="h-4 w-4 text-red-600" />
+    },
+    {
+      key: 'additionalSpecs',
+      label: 'Additional Specifications',
+      placeholder: 'Any other important specs (GPU, ports, weight, etc.)',
+      textarea: true
+    }
+  ],
+  vehicle: [
+    {
+      key: 'fuelType',
+      label: 'Fuel Type',
+      placeholder: 'e.g., Gasoline, Electric',
+      icon: <Car className="h-4 w-4 text-blue-600" />
+    },
+    {
+      key: 'modelYear',
+      label: 'Model Year',
+      placeholder: 'e.g., 2024'
+    },
+    {
+      key: 'transmission',
+      label: 'Transmission',
+      placeholder: 'e.g., Automatic'
+    },
+    {
+      key: 'additionalSpecs',
+      label: 'Additional Specifications',
+      placeholder: 'Any other important specs (trim, mileage, etc.)',
+      textarea: true
+    }
+  ]
+};
 
 interface PreciseSpecsDialogProps {
   isOpen: boolean;
@@ -14,27 +100,29 @@ interface PreciseSpecsDialogProps {
   onSkip: () => void;
   isPaidUser?: boolean;
   device?: string;
+  category?: string;
 }
 
-interface PreciseSpecs {
-  processor: string;
-  ram: string;
-  storage: string;
-  display: string;
-  battery: string;
-  additionalSpecs: string;
-}
+type PreciseSpecs = Record<string, string>;
 
-const emptySpecs: PreciseSpecs = {
-  processor: '',
-  ram: '',
-  storage: '',
-  display: '',
-  battery: '',
-  additionalSpecs: ''
+const buildEmptySpecs = (category: string): PreciseSpecs => {
+  const fields = FIELD_SETS[category] || FIELD_SETS.computer;
+  return fields.reduce<PreciseSpecs>((acc, f) => {
+    acc[f.key] = '';
+    return acc;
+  }, {} as PreciseSpecs);
 };
 
-const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit, onSkip, isPaidUser = false, device }: PreciseSpecsDialogProps) => {
+const PreciseSpecsDialog = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  onSkip,
+  isPaidUser = false,
+  device,
+  category = 'computer'
+}: PreciseSpecsDialogProps) => {
+  const emptySpecs = buildEmptySpecs(category);
   const [specsList, setSpecsList] = useState<PreciseSpecs[]>([ { ...emptySpecs } ]);
 
   const addDevice = () => {
@@ -63,7 +151,7 @@ const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit, onSkip, isPaidUser = fa
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
-        className="sm:max-w-lg max-h-[80vh] overflow-y-auto"
+        className="sm:max-w-lg max-h-[80vh] overflow-y-auto overflow-x-hidden"
         aria-describedby="precise-specs-desc"
       >
         <DialogHeader>
@@ -83,78 +171,42 @@ const PreciseSpecsDialog = ({ isOpen, onClose, onSubmit, onSkip, isPaidUser = fa
         
         <form onSubmit={handleSubmit} className="space-y-6">
           {specsList.map((specs, idx) => (
-            <div key={idx} className="space-y-4 border-b pb-4 last:border-none last:pb-0">
+            <div
+              key={idx}
+              className="space-y-4 border-b pb-4 last:border-none last:pb-0"
+            >
               <h3 className="font-semibold">Device {idx + 1}</h3>
-              <div className="space-y-2">
-                <Label htmlFor={`processor-${idx}`} className="flex items-center space-x-2">
-                  <Cpu className="h-4 w-4 text-blue-600" />
-                  <span>Processor</span>
-                </Label>
-                <Input
-                  id={`processor-${idx}`}
-                  placeholder="e.g., Apple M3, Intel Core i7-13700H"
-                  value={specs.processor}
-                  onChange={(e) => handleInputChange(idx, 'processor', e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor={`ram-${idx}`} className="flex items-center space-x-2">
-                  <HardDrive className="h-4 w-4 text-green-600" />
-                  <span>RAM</span>
-                </Label>
-                <Input
-                  id={`ram-${idx}`}
-                  placeholder="e.g., 16GB LPDDR5, 32GB DDR4"
-                  value={specs.ram}
-                  onChange={(e) => handleInputChange(idx, 'ram', e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor={`storage-${idx}`} className="flex items-center space-x-2">
-                  <HardDrive className="h-4 w-4 text-purple-600" />
-                  <span>Storage</span>
-                </Label>
-                <Input
-                  id={`storage-${idx}`}
-                  placeholder="e.g., 512GB SSD, 1TB NVMe"
-                  value={specs.storage}
-                  onChange={(e) => handleInputChange(idx, 'storage', e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor={`display-${idx}`} className="flex items-center space-x-2">
-                  <Monitor className="h-4 w-4 text-orange-600" />
-                  <span>Display</span>
-                </Label>
-                <Input
-                  id={`display-${idx}`}
-                  placeholder='e.g., 13.6" Liquid Retina, 15.6" OLED 4K'
-                  value={specs.display}
-                  onChange={(e) => handleInputChange(idx, 'display', e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor={`battery-${idx}`} className="flex items-center space-x-2">
-                  <Battery className="h-4 w-4 text-red-600" />
-                  <span>Battery Life</span>
-                </Label>
-                <Input
-                  id={`battery-${idx}`}
-                  placeholder="e.g., 18 hours, 5000mAh"
-                  value={specs.battery}
-                  onChange={(e) => handleInputChange(idx, 'battery', e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor={`additional-${idx}`}>Additional Specifications</Label>
-                <Textarea
-                  id={`additional-${idx}`}
-                  placeholder="Any other important specs (GPU, ports, weight, etc.)"
-                  value={specs.additionalSpecs}
-                  onChange={(e) => handleInputChange(idx, 'additionalSpecs', e.target.value)}
-                  rows={3}
-                />
-              </div>
+              {FIELD_SETS[category]?.map((field) => (
+                <div key={field.key} className="space-y-2">
+                  <Label
+                    htmlFor={`${field.key}-${idx}`}
+                    className="flex items-center space-x-2"
+                  >
+                    {field.icon}
+                    <span>{field.label}</span>
+                  </Label>
+                  {field.textarea ? (
+                    <Textarea
+                      id={`${field.key}-${idx}`}
+                      placeholder={field.placeholder}
+                      value={specs[field.key] || ''}
+                      onChange={(e) =>
+                        handleInputChange(idx, field.key as keyof PreciseSpecs, e.target.value)
+                      }
+                      rows={3}
+                    />
+                  ) : (
+                    <Input
+                      id={`${field.key}-${idx}`}
+                      placeholder={field.placeholder}
+                      value={specs[field.key] || ''}
+                      onChange={(e) =>
+                        handleInputChange(idx, field.key as keyof PreciseSpecs, e.target.value)
+                      }
+                    />
+                  )}
+                </div>
+              ))}
             </div>
           ))}
           {(isPaidUser || specsList.length < 2) && (

--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -47,6 +47,7 @@ export const useComparisonForm = () => {
   const [notFoundProduct, setNotFoundProduct] = useState('');
   const [preciseDevice, setPreciseDevice] = useState('');
   const [pendingComparison, setPendingComparison] = useState<ComparisonData | null>(null);
+  const [category, setCategory] = useState<string>('computer');
 
   const { toast } = useToast();
   
@@ -87,6 +88,9 @@ export const useComparisonForm = () => {
           currentProduct,
           newProduct
         );
+        if (compatibility.category1 === compatibility.category2) {
+          setCategory(compatibility.category1);
+        }
 
         if (!compatibility.comparable) {
           setComparisonResult({
@@ -215,6 +219,7 @@ export const useComparisonForm = () => {
     setShowPreciseSpecs(false);
     setNotFoundProduct('');
     setPreciseDevice('');
+    setCategory('computer');
   };
 
   return {
@@ -230,6 +235,7 @@ export const useComparisonForm = () => {
     showPreciseSpecs,
     notFoundProduct,
     preciseDevice,
+    category,
     isLoading,
     
     // State setters

--- a/tests/PreciseSpecsDialog.test.tsx
+++ b/tests/PreciseSpecsDialog.test.tsx
@@ -18,4 +18,33 @@ describe('PreciseSpecsDialog', () => {
     );
     expect(screen.getByText(/More details are needed for/i)).toHaveTextContent('MacBook Pro');
   });
+
+  it('renders computer spec fields by default', () => {
+    render(
+      <PreciseSpecsDialog
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onSkip={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText(/Processor/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/RAM/i)).toBeInTheDocument();
+  });
+
+  it('renders vehicle spec fields when category is vehicle', () => {
+    render(
+      <PreciseSpecsDialog
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onSkip={() => {}}
+        category="vehicle"
+      />
+    );
+
+    expect(screen.getByLabelText(/Fuel Type/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Model Year/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- prevent horizontal scroll in PreciseSpecsDialog
- allow PreciseSpecsDialog to show fields based on category
- plumb category through useComparisonForm and ComparisonForm
- update tests for category-specific fields

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6875efb973dc8330b63cc844891e678a