### PR TITLE
Move skip button before form inputs

### DIFF
--- a/src/components/PreciseSpecsDialog.tsx
+++ b/src/components/PreciseSpecsDialog.tsx
@@ -170,6 +170,16 @@ const PreciseSpecsDialog = ({
         )}
         
         <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="secondary"
+              className="font-bold"
+              onClick={onSkip}
+            >
+              Whatever, just compare the most common configuration.
+            </Button>
+          </div>
           {specsList.map((specs, idx) => (
             <div
               key={idx}
@@ -220,9 +230,6 @@ const PreciseSpecsDialog = ({
             </p>
           </div>
           <div className="flex flex-col sm:flex-row sm:justify-end sm:space-x-2 space-y-2 sm:space-y-0">
-            <Button type="button" variant="ghost" onClick={onSkip}>
-              Whatever, just compare the most common configuration.
-            </Button>
             <Button type="button" variant="outline" onClick={onClose}>
               Cancel
             </Button>

--- a/tests/PreciseSpecsDialog.test.tsx
+++ b/tests/PreciseSpecsDialog.test.tsx
@@ -47,4 +47,22 @@ describe('PreciseSpecsDialog', () => {
     expect(screen.getByLabelText(/Fuel Type/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Model Year/i)).toBeInTheDocument();
   });
+
+  it('places the skip button before other actions', () => {
+    render(
+      <PreciseSpecsDialog
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onSkip={() => {}}
+      />
+    );
+
+    const skipButton = screen.getByText(/Whatever, just compare/i);
+    const cancelButton = screen.getByText('Cancel');
+
+    // Ensure the skip button appears before the cancel button in the DOM
+    const position = skipButton.compareDocumentPosition(cancelButton);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
 });


### PR DESCRIPTION
## Summary
- move "Whatever" skip button to the top of `PreciseSpecsDialog`
- make the skip button bold and use the secondary variant
- update dialog test to ensure skip button comes first

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6875f1686c6c8330907d0abf585f10a9