### PR TITLE
Implement immediate loading state

### DIFF
--- a/src/components/ComparisonForm.tsx
+++ b/src/components/ComparisonForm.tsx
@@ -24,6 +24,7 @@ const ComparisonForm = () => {
     preciseDevice,
     category,
     isLoading,
+    isSubmitting,
     setShowProductNotFound,
     setShowQueue,
     setShowPreciseSpecs,
@@ -77,6 +78,7 @@ const ComparisonForm = () => {
         newProduct={newProduct}
         setNewProduct={setNewProduct}
         isLoading={isLoading}
+        isSubmitting={isSubmitting}
         onSubmit={handleSubmit}
       />
 

--- a/src/components/ComparisonFormInputs.tsx
+++ b/src/components/ComparisonFormInputs.tsx
@@ -13,6 +13,7 @@ interface ComparisonFormInputsProps {
   newProduct: string;
   setNewProduct: (value: string) => void;
   isLoading: boolean;
+  isSubmitting?: boolean;
   onSubmit: (e: React.FormEvent) => void;
 }
 
@@ -22,8 +23,10 @@ const ComparisonFormInputs = ({
   newProduct,
   setNewProduct,
   isLoading,
+  isSubmitting = false,
   onSubmit
 }: ComparisonFormInputsProps) => {
+  const busy = isLoading || isSubmitting;
   return (
     <div className="w-full max-w-2xl mx-auto animate-slide-up space-y-6">
       {/* Free Service Indicator */}
@@ -52,7 +55,7 @@ const ComparisonFormInputs = ({
                 onChange={(e) => setCurrentProduct(e.target.value)}
                 className="h-14 text-lg bg-tech-gray-50/50 border-tech-gray-300 focus:border-tech-electric focus:ring-tech-electric/30 focus:shadow-neon transition-all duration-300 rounded-xl"
                 required
-                disabled={isLoading}
+                disabled={busy}
               />
             </div>
 
@@ -80,16 +83,16 @@ const ComparisonFormInputs = ({
                 onChange={(e) => setNewProduct(e.target.value)}
                 className="h-14 text-lg bg-tech-gray-50/50 border-tech-gray-300 focus:border-tech-electric focus:ring-tech-electric/30 focus:shadow-neon transition-all duration-300 rounded-xl"
                 required
-                disabled={isLoading}
+                disabled={busy}
               />
             </div>
 
             <Button
               type="submit"
-              disabled={!currentProduct.trim() || !newProduct.trim() || isLoading}
+              disabled={!currentProduct.trim() || !newProduct.trim() || busy}
               className="w-full h-14 text-lg font-semibold bg-gradient-tech hover:shadow-electric text-white transition-all duration-300 rounded-xl group disabled:opacity-50"
             >
-              {isLoading ? (
+              {busy ? (
                 <>
                   <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                   Analyzing...
@@ -102,12 +105,12 @@ const ComparisonFormInputs = ({
               )}
             </Button>
           </form>
-          {isLoading && (
+          {busy && (
             <div className="mt-6 space-y-4 text-center">
               <p className="text-sm text-tech-gray-500">
                 Interrogating the AI, this might take a moment… Enjoy a little game in the meantime?
               </p>
-              <SnakeGame active={isLoading} />
+              <SnakeGame active={busy} />
             </div>
           )}
         </CardContent>

--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -48,6 +48,7 @@ export const useComparisonForm = () => {
   const [preciseDevice, setPreciseDevice] = useState('');
   const [pendingComparison, setPendingComparison] = useState<ComparisonData | null>(null);
   const [category, setCategory] = useState<string>('computer');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { toast } = useToast();
   
@@ -55,18 +56,22 @@ export const useComparisonForm = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
+    setIsSubmitting(true);
+
     console.log('Form submitted with:', { currentProduct, newProduct });
     
     // Check for special mock triggers
     if (currentProduct.toLowerCase() === 'error' || newProduct.toLowerCase() === 'error') {
       setNotFoundProduct(currentProduct.toLowerCase() === 'error' ? currentProduct : newProduct);
       setShowProductNotFound(true);
+      setIsSubmitting(false);
       return;
     }
     
     if (currentProduct.toLowerCase() === 'queue' || newProduct.toLowerCase() === 'queue') {
       setShowQueue(true);
+      setIsSubmitting(false);
       return;
     }
 
@@ -77,6 +82,7 @@ export const useComparisonForm = () => {
       // Check first if quota isn't exceeded
       if (geminiService.isQuotaExceeded()) {
         setShowQueueStatus(true);
+        setIsSubmitting(false);
         return;
       }
       
@@ -99,6 +105,7 @@ export const useComparisonForm = () => {
             newDevice: newProduct,
             explanation: `I cannot compare "${currentProduct}" and "${newProduct}" because they belong to different categories (${compatibility.category1} vs ${compatibility.category2}).`
           });
+          setIsSubmitting(false);
           return;
         }
 
@@ -115,6 +122,7 @@ export const useComparisonForm = () => {
               : newProduct;
           setPreciseDevice(deviceInfo);
           setShowPreciseSpecs(true);
+          setIsSubmitting(false);
           return;
         }
 
@@ -123,9 +131,11 @@ export const useComparisonForm = () => {
           setPendingComparison(result);
           setPreciseDevice(currentProduct);
           setShowPreciseSpecs(true);
+          setIsSubmitting(false);
           return;
         }
         setComparisonResult(result);
+        setIsSubmitting(false);
       } catch (error) {
         console.error('Comparison failed:', error);
         logDevError('Comparison failed', error);
@@ -148,6 +158,7 @@ export const useComparisonForm = () => {
             variant: 'destructive'
           });
         }
+        setIsSubmitting(false);
       }
     }
   };
@@ -220,6 +231,7 @@ export const useComparisonForm = () => {
     setNotFoundProduct('');
     setPreciseDevice('');
     setCategory('computer');
+    setIsSubmitting(false);
   };
 
   return {
@@ -237,6 +249,7 @@ export const useComparisonForm = () => {
     preciseDevice,
     category,
     isLoading,
+    isSubmitting,
     
     // State setters
     setShowProductNotFound,

--- a/tests/ComparisonForm.test.tsx
+++ b/tests/ComparisonForm.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import ComparisonForm from '../src/components/ComparisonForm';
+
+const deferred = () => {
+  let resolveFn: (v: any) => void = () => {};
+  const promise = new Promise<any>((r) => {
+    resolveFn = r;
+  });
+  return { promise, resolve: resolveFn };
+};
+
+const analysis = deferred();
+
+vi.mock('../src/hooks/useMockData', () => ({
+  useMockData: () => ({
+    isLoading: false,
+    simulateAnalysis: vi.fn(() => analysis.promise)
+  })
+}));
+
+vi.mock('../src/services/geminiService', () => ({
+  geminiService: {
+    isQuotaExceeded: vi.fn(() => false),
+    checkComparability: vi.fn(() =>
+      Promise.resolve({ comparable: true, category1: 'computer', category2: 'computer' })
+    ),
+    checkDetailCompleteness: vi.fn(() =>
+      Promise.resolve({
+        current: { complete: true, missing: [] },
+        new: { complete: true, missing: [] }
+      })
+    )
+  }
+}));
+
+describe('ComparisonForm', () => {
+  it('shows loading state immediately after submission', async () => {
+    render(<ComparisonForm />);
+
+    await userEvent.type(screen.getByLabelText(/current device/i), 'a');
+    await userEvent.type(screen.getByLabelText(/Device you're considering/i), 'b');
+
+    await userEvent.click(screen.getByRole('button', { name: /compare now/i }));
+
+    expect(await screen.findByText(/Analyzing/i)).toBeInTheDocument();
+
+    analysis.resolve({
+      isIncompatible: true,
+      currentDevice: 'a',
+      newDevice: 'b',
+      explanation: 'x'
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `isSubmitting` state to `useComparisonForm`
- pass submission flag to `ComparisonFormInputs`
- show button loading based on `busy` status
- test that loader appears right after form submission

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875f42d35488330a0a833ba107ddbef