### PR TITLE
Add confirmation dialog when navigating home

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { ComparisonResultProvider } from "@/contexts/ComparisonResultContext";
 import Index from "./pages/Index";
 import Contact from "./pages/Contact";
 import Privacy from "./pages/Privacy";
@@ -17,16 +18,18 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
+      <ComparisonResultProvider>
+        <BrowserRouter>
+          <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/terms" element={<Terms />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+          </Routes>
+        </BrowserRouter>
+      </ComparisonResultProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,19 +1,34 @@
 
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { useComparisonResult } from '@/contexts/ComparisonResultContext';
 
 const Header = () => {
+  const { hasResult } = useComparisonResult();
+
+  const handleHomeClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (hasResult) {
+      const proceed = window.confirm(
+        'You have a comparison result. Navigating away will lose it. Continue?'
+      );
+      if (!proceed) {
+        e.preventDefault();
+      }
+    }
+  };
+
   return (
     <header className="sticky top-0 z-50 w-full bg-white/90 backdrop-blur-xl border-b border-tech-gray-200/50 shadow-electric">
       <div className="container mx-auto px-6 py-4">
         <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-3">
+          <Link to="/" onClick={handleHomeClick} className="flex items-center space-x-3">
             <div className="w-8 h-8 bg-gradient-tech rounded-xl flex items-center justify-center shadow-neon">
               <span className="text-white font-bold text-sm">IB</span>
             </div>
             <h1 className="text-xl font-bold bg-gradient-dark bg-clip-text text-transparent">
               Is it Better?
             </h1>
-          </div>
+          </Link>
           <div className="hidden md:flex items-center space-x-6 text-sm">
             <span className="bg-gradient-to-r from-tech-electric/10 to-tech-neon/10 text-tech-electric px-4 py-2 rounded-full font-semibold border border-tech-electric/20">
               ✨ 100% Free

--- a/src/contexts/ComparisonResultContext.tsx
+++ b/src/contexts/ComparisonResultContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface ComparisonResultContextValue {
+  hasResult: boolean;
+  setHasResult: (value: boolean) => void;
+}
+
+const ComparisonResultContext = createContext<ComparisonResultContextValue>({
+  hasResult: false,
+  setHasResult: () => {},
+});
+
+interface ProviderProps {
+  children: React.ReactNode;
+  initialHasResult?: boolean;
+}
+
+export const ComparisonResultProvider = ({ children, initialHasResult = false }: ProviderProps) => {
+  const [hasResult, setHasResult] = useState(initialHasResult);
+  return (
+    <ComparisonResultContext.Provider value={{ hasResult, setHasResult }}>
+      {children}
+    </ComparisonResultContext.Provider>
+  );
+};
+
+export const useComparisonResult = () => useContext(ComparisonResultContext);
+
+export default ComparisonResultContext;

--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useMockData } from '@/hooks/useMockData';
 import { logDevError } from '@/lib/devLogger';
 import { geminiService } from '@/services/geminiService';
 import { useToast } from '@/hooks/use-toast';
 import { GeminiParseError, GeminiTokenLimitError } from '@/utils/geminiErrors';
 import { needsPreciseSpecs } from '@/utils/specCheck';
+import { useComparisonResult } from '@/contexts/ComparisonResultContext';
 
 interface ComparisonData {
   currentDevice: string;
@@ -50,9 +51,15 @@ export const useComparisonForm = () => {
   const [category, setCategory] = useState<string>('computer');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const { setHasResult } = useComparisonResult();
+
   const { toast } = useToast();
-  
+
   const { isLoading, simulateAnalysis } = useMockData();
+
+  useEffect(() => {
+    setHasResult(comparisonResult !== null);
+  }, [comparisonResult, setHasResult]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -224,6 +231,7 @@ export const useComparisonForm = () => {
     setCurrentProduct('');
     setNewProduct('');
     setComparisonResult(null);
+    setHasResult(false);
     setShowQueueStatus(false);
     setShowProductNotFound(false);
     setShowQueue(false);

--- a/tests/Header.test.tsx
+++ b/tests/Header.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Header from '../src/components/Header';
+import { ComparisonResultProvider } from '../src/contexts/ComparisonResultContext';
+import '@testing-library/jest-dom';
+
+describe('Header navigation', () => {
+  it('prompts before navigating when a result exists', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(
+      <ComparisonResultProvider initialHasResult={true}>
+        <MemoryRouter>
+          <Header />
+        </MemoryRouter>
+      </ComparisonResultProvider>
+    );
+
+    await userEvent.click(screen.getByRole('link', { name: /is it better/i }));
+    expect(confirmSpy).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap header logo in router `Link`
- cancel navigation if a comparison result exists and the user declines
- track whether a result exists via new `ComparisonResultContext`
- integrate context into the comparison form
- cover prompt behavior in a new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876016ecb80833086df3ae673ccc3eb