### PR TITLE
Fix precise specs dialog category & text

### DIFF
--- a/src/components/PreciseSpecsDialog.tsx
+++ b/src/components/PreciseSpecsDialog.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState } from 'react';
+import { normalizeCategory } from '@/utils/productCategories';
 import {
   Dialog,
   DialogContent,
@@ -106,7 +107,8 @@ interface PreciseSpecsDialogProps {
 type PreciseSpecs = Record<string, string>;
 
 const buildEmptySpecs = (category: string): PreciseSpecs => {
-  const fields = FIELD_SETS[category] || FIELD_SETS.computer;
+  const normalized = normalizeCategory(category);
+  const fields = FIELD_SETS[normalized] || FIELD_SETS.computer;
   return fields.reduce<PreciseSpecs>((acc, f) => {
     acc[f.key] = '';
     return acc;
@@ -122,7 +124,8 @@ const PreciseSpecsDialog = ({
   device,
   category = 'computer'
 }: PreciseSpecsDialogProps) => {
-  const emptySpecs = buildEmptySpecs(category);
+  const normalizedCategory = normalizeCategory(category);
+  const emptySpecs = buildEmptySpecs(normalizedCategory);
   const [specsList, setSpecsList] = useState<PreciseSpecs[]>([ { ...emptySpecs } ]);
 
   const addDevice = () => {
@@ -157,7 +160,7 @@ const PreciseSpecsDialog = ({
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <Settings className="h-5 w-5 text-blue-500" />
-            <span>Specify Precise Specifications</span>
+            <span>Precise Specifications</span>
           </DialogTitle>
         </DialogHeader>
         <DialogDescription id="precise-specs-desc">
@@ -174,10 +177,11 @@ const PreciseSpecsDialog = ({
             <Button
               type="button"
               variant="secondary"
+              size="lg"
               className="font-bold"
               onClick={onSkip}
             >
-              Whatever, just compare the most common configuration.
+              Whatever, just compare the most common specifications.
             </Button>
           </div>
           {specsList.map((specs, idx) => (
@@ -186,7 +190,7 @@ const PreciseSpecsDialog = ({
               className="space-y-4 border-b pb-4 last:border-none last:pb-0"
             >
               <h3 className="font-semibold">Device {idx + 1}</h3>
-              {FIELD_SETS[category]?.map((field) => (
+              {FIELD_SETS[normalizedCategory]?.map((field) => (
                 <div key={field.key} className="space-y-2">
                   <Label
                     htmlFor={`${field.key}-${idx}`}

--- a/src/utils/productCategories.test.ts
+++ b/src/utils/productCategories.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getProductCategory, areProductsComparable, generateIncompatibleExplanation } from './productCategories';
+import { getProductCategory, areProductsComparable, generateIncompatibleExplanation, normalizeCategory } from './productCategories';
 
 describe('getProductCategory', () => {
   it('detects electronics category', () => {
@@ -40,5 +40,15 @@ describe('generateIncompatibleExplanation', () => {
     expect(message).toContain('Toyota car');
     expect(message).toContain('electronics');
     expect(message).toContain('vehicles');
+  });
+});
+
+describe('normalizeCategory', () => {
+  it('maps plural categories to singular form', () => {
+    expect(normalizeCategory('vehicles')).toBe('vehicle');
+  });
+
+  it('keeps unknown categories unchanged', () => {
+    expect(normalizeCategory('lighting')).toBe('lighting');
   });
 });

--- a/src/utils/productCategories.ts
+++ b/src/utils/productCategories.ts
@@ -18,6 +18,17 @@ export const getProductCategory = (product: string): string | null => {
   return null;
 };
 
+export const normalizeCategory = (category: string): string => {
+  switch (category) {
+    case 'vehicles':
+      return 'vehicle';
+    case 'electronics':
+      return 'computer';
+    default:
+      return category;
+  }
+};
+
 export const areProductsComparable = (product1: string, product2: string): boolean => {
   const category1 = getProductCategory(product1);
   const category2 = getProductCategory(product2);

--- a/tests/PreciseSpecsDialog.test.tsx
+++ b/tests/PreciseSpecsDialog.test.tsx
@@ -48,6 +48,21 @@ describe('PreciseSpecsDialog', () => {
     expect(screen.getByLabelText(/Model Year/i)).toBeInTheDocument();
   });
 
+  it('renders vehicle spec fields when category is vehicles', () => {
+    render(
+      <PreciseSpecsDialog
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onSkip={() => {}}
+        category="vehicles"
+      />
+    );
+
+    expect(screen.getByLabelText(/Fuel Type/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Model Year/i)).toBeInTheDocument();
+  });
+
   it('places the skip button before other actions', () => {
     render(
       <PreciseSpecsDialog


### PR DESCRIPTION
## Summary
- normalize category names like `vehicles` -> `vehicle`
- show correct fields for plural vehicle categories
- rename dialog title to `Precise Specifications`
- highlight skip button and tweak copy
- test new `normalizeCategory` helper and plural category support

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68763d81c50c833088fd37ac908b9a4d