### PR TITLE
Add AI disclaimer under analysis buttons

### DIFF
--- a/src/components/ComparisonFormInputs.tsx
+++ b/src/components/ComparisonFormInputs.tsx
@@ -104,6 +104,9 @@ const ComparisonFormInputs = ({
                 </>
               )}
             </Button>
+            <p className="mt-2 text-xs text-tech-gray-400 text-center">
+              AI can make mistakes. Please verify key informations before considering a purchase.
+            </p>
           </form>
           {busy && (
             <div className="mt-6 space-y-4 text-center">

--- a/src/components/MultiCompare.tsx
+++ b/src/components/MultiCompare.tsx
@@ -209,6 +209,9 @@ const MultiCompare = ({ onClose }: MultiCompareProps) => {
                 </>
               )}
             </Button>
+            <p className="mt-2 text-xs text-tech-gray-400 text-center">
+              AI can make mistakes. Please verify key informations before considering a purchase.
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/src/components/PreciseSpecsDialog.tsx
+++ b/src/components/PreciseSpecsDialog.tsx
@@ -239,6 +239,9 @@ const PreciseSpecsDialog = ({
             </Button>
             <Button type="submit">Analyze with Precise Specs</Button>
           </div>
+          <p className="mt-2 text-xs text-tech-gray-400 text-center">
+            AI can make mistakes. Please verify key informations before considering a purchase.
+          </p>
         </form>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- add disclaimer under main comparison form's button
- show same note in multi-comparison and precise specs dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876416d96d083309738eb4920c0a3c2