### PR TITLE
Improve skip button styling

### DIFF
--- a/src/components/PreciseSpecsDialog.tsx
+++ b/src/components/PreciseSpecsDialog.tsx
@@ -176,9 +176,9 @@ const PreciseSpecsDialog = ({
           <div className="flex justify-end">
             <Button
               type="button"
-              variant="secondary"
+              variant="default"
               size="lg"
-              className="font-bold"
+              className="font-bold border-2 border-primary"
               onClick={onSkip}
             >
               Whatever, just compare the most common specifications.


### PR DESCRIPTION
## Summary
- make the skip button use the default variant with a bold border

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687755ed670883308efe5112ea29cdf8