### PR TITLE
Fix PreciseSpecsDialog aria warning

### DIFF
--- a/src/components/PreciseSpecsDialog.tsx
+++ b/src/components/PreciseSpecsDialog.tsx
@@ -155,7 +155,6 @@ const PreciseSpecsDialog = ({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
         className="sm:max-w-lg max-h-[80vh] overflow-y-auto overflow-x-hidden"
-        aria-describedby="precise-specs-desc"
       >
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
@@ -163,7 +162,7 @@ const PreciseSpecsDialog = ({
             <span>Precise Specifications</span>
           </DialogTitle>
         </DialogHeader>
-        <DialogDescription id="precise-specs-desc">
+        <DialogDescription>
           Provide detailed hardware specifications for a more accurate comparison.
         </DialogDescription>
         {device && (


### PR DESCRIPTION
## Summary
- rely on Radix dialog to generate description id automatically

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68775c4c720c8330b387069f7123445a