### PR TITLE
Add test for PreciseSpecs dialog visibility

### DIFF
--- a/tests/ComparisonDialogs.test.tsx
+++ b/tests/ComparisonDialogs.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ComparisonDialogs from '../src/components/ComparisonDialogs';
+
+describe('ComparisonDialogs', () => {
+  it('renders PreciseSpecsDialog fields when showPreciseSpecs is true', () => {
+    render(
+      <ComparisonDialogs
+        showProductNotFound={false}
+        setShowProductNotFound={() => {}}
+        notFoundProduct=""
+        showQueue={false}
+        setShowQueue={() => {}}
+        showPreciseSpecs={true}
+        setShowPreciseSpecs={() => {}}
+        onPreciseSpecsSubmit={() => {}}
+        onSkipPreciseSpecs={() => {}}
+        preciseDevice="Device A"
+        category="computer"
+      />
+    );
+
+    expect(screen.getByLabelText(/Processor/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/RAM/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the PreciseSpecs dialog opens when `showPreciseSpecs` is true

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877b814c15483308f25e72b6f217359