### PR TITLE
Recognize smartphone brands

### DIFF
--- a/src/utils/productCategories.test.ts
+++ b/src/utils/productCategories.test.ts
@@ -14,6 +14,10 @@ describe('getProductCategory', () => {
     expect(getProductCategory('ampoule LED')).toBe('lighting');
   });
 
+  it('detects smartphone brands as electronics', () => {
+    expect(getProductCategory('Xiaomi 12')).toBe('electronics');
+  });
+
   it('returns null for unknown product', () => {
     expect(getProductCategory('some random item')).toBeNull();
   });

--- a/src/utils/productCategories.ts
+++ b/src/utils/productCategories.ts
@@ -1,6 +1,22 @@
 
 export const productCategories = {
-  'electronics': ['macbook', 'iphone', 'samsung', 'laptop', 'phone', 'tablet', 'computer'],
+  'electronics': [
+    'macbook',
+    'iphone',
+    'samsung',
+    'xiaomi',
+    'pixel',
+    'google',
+    'oneplus',
+    'huawei',
+    'sony',
+    'oppo',
+    'smartphone',
+    'laptop',
+    'phone',
+    'tablet',
+    'computer'
+  ],
   'vehicles': ['car', 'voiture', 'vélo', 'bike', 'bicycle', 'motorcycle', 'moto'],
   'lighting': ['ampoule', 'bulb', 'led', 'lamp', 'éclairage'],
   'appliances': ['refrigerator', 'frigo', 'washing machine', 'lave-linge', 'microwave']


### PR DESCRIPTION
## Summary
- extend electronics keywords to include common smartphone manufacturers
- test for smartphone detection in product categories

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877c6e4a9d08330b9300ef69029b0c2