### PR TITLE
Improve loading UX and snake game

### DIFF
--- a/src/components/ComparisonFormInputs.tsx
+++ b/src/components/ComparisonFormInputs.tsx
@@ -27,6 +27,7 @@ const ComparisonFormInputs = ({
   onSubmit
 }: ComparisonFormInputsProps) => {
   const busy = isLoading || isSubmitting;
+  const busyStage = isSubmitting && !isLoading ? 'checking' : isLoading ? 'analyzing' : null;
   return (
     <div className="w-full max-w-2xl mx-auto animate-slide-up space-y-6">
       {/* Free Service Indicator */}
@@ -95,7 +96,7 @@ const ComparisonFormInputs = ({
               {busy ? (
                 <>
                   <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-                  Analyzing...
+                  {busyStage === 'checking' ? 'Checking specs...' : 'Analyzing...'}
                 </>
               ) : (
                 <>
@@ -111,9 +112,11 @@ const ComparisonFormInputs = ({
           {busy && (
             <div className="mt-6 space-y-4 text-center">
               <p className="text-sm text-tech-gray-500">
-                Interrogating the AI, this might take a moment… Enjoy a little game in the meantime?
+                {busyStage === 'checking'
+                  ? 'Checking if we have all the necessary specs...'
+                  : 'Interrogating the AI and analyzing, this might take a moment...'}
               </p>
-              <SnakeGame active={busy} />
+              {busyStage === 'analyzing' && <SnakeGame active={true} />}
             </div>
           )}
         </CardContent>

--- a/src/components/ComparisonResult.tsx
+++ b/src/components/ComparisonResult.tsx
@@ -202,9 +202,15 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
                     <TableHeader>
                       <TableRow>
                         <TableHead className="font-bold text-tech-dark">Component</TableHead>
-                        <TableHead className="font-bold text-tech-dark text-center">{data.currentDevice}</TableHead>
+                        <TableHead className="font-bold text-tech-dark text-center">
+                          <div className="text-sm font-semibold text-tech-electric mb-1">{data.currentDevice}</div>
+                          <div className="text-xs text-tech-gray-600 font-normal">Current</div>
+                        </TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">Impact</TableHead>
-                        <TableHead className="font-bold text-tech-dark text-center">{data.newDevice}</TableHead>
+                        <TableHead className="font-bold text-tech-dark text-center">
+                          <div className="text-sm font-semibold text-tech-electric mb-1">{data.newDevice}</div>
+                          <div className="text-xs text-tech-gray-600 font-normal">New</div>
+                        </TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">Why Better?</TableHead>
                       </TableRow>
                     </TableHeader>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,20 @@
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useComparisonResult } from '@/contexts/ComparisonResultContext';
 
 const Header = () => {
   const { hasResult } = useComparisonResult();
+  const navigate = useNavigate();
 
   const handleHomeClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (hasResult) {
+      e.preventDefault();
       const proceed = window.confirm(
         'You have a comparison result. Navigating away will lose it. Continue?'
       );
-      if (!proceed) {
-        e.preventDefault();
+      if (proceed) {
+        navigate('/', { replace: true });
       }
     }
   };

--- a/src/components/SnakeGame.tsx
+++ b/src/components/SnakeGame.tsx
@@ -19,6 +19,8 @@ interface SnakeGameProps {
 const SnakeGame = ({ active }: SnakeGameProps) => {
   const [snake, setSnake] = useState<Point[]>(INITIAL_SNAKE);
   const [food, setFood] = useState<Point>(randomFood());
+  const [score, setScore] = useState(0);
+  const [gameOver, setGameOver] = useState(false);
   const directionRef = useRef<Point>({ x: 1, y: 0 });
 
   useEffect(() => {
@@ -41,10 +43,19 @@ const SnakeGame = ({ active }: SnakeGameProps) => {
           x: (head.x + directionRef.current.x + BOARD_SIZE) % BOARD_SIZE,
           y: (head.y + directionRef.current.y + BOARD_SIZE) % BOARD_SIZE
         };
-        const newSnake = [newHead, ...prev.slice(0, prev.length - 1)];
-        if (newHead.x === food.x && newHead.y === food.y) {
+
+        if (prev.some(p => p.x === newHead.x && p.y === newHead.y)) {
+          setGameOver(true);
+          return prev;
+        }
+
+        const grows = newHead.x === food.x && newHead.y === food.y;
+        const newSnake = [newHead, ...prev];
+        if (!grows) {
+          newSnake.pop();
+        } else {
           setFood(randomFood());
-          newSnake.push(prev[prev.length - 1]);
+          setScore(s => s + 1);
         }
         return newSnake;
       });
@@ -52,16 +63,30 @@ const SnakeGame = ({ active }: SnakeGameProps) => {
     return () => clearInterval(id);
   }, [active, food]);
 
+  useEffect(() => {
+    if (active) {
+      setSnake(INITIAL_SNAKE);
+      setFood(randomFood());
+      setScore(0);
+      setGameOver(false);
+      directionRef.current = { x: 1, y: 0 };
+    }
+  }, [active]);
+
   return (
-    <div className="grid grid-cols-10 gap-0.5 w-40 mx-auto">
-      {Array.from({ length: BOARD_SIZE * BOARD_SIZE }).map((_, i) => {
-        const x = i % BOARD_SIZE;
-        const y = Math.floor(i / BOARD_SIZE);
-        const isSnake = snake.some(p => p.x === x && p.y === y);
-        const isFood = food.x === x && food.y === y;
-        const bg = isFood ? 'bg-red-500' : isSnake ? 'bg-green-600' : 'bg-gray-200';
-        return <div key={i} className={`w-3 h-3 ${bg}`}></div>;
-      })}
+    <div className="text-center">
+      <div className="text-xs mb-1">Score: {score}</div>
+      <div className="grid grid-cols-10 gap-0.5 w-40 mx-auto">
+        {Array.from({ length: BOARD_SIZE * BOARD_SIZE }).map((_, i) => {
+          const x = i % BOARD_SIZE;
+          const y = Math.floor(i / BOARD_SIZE);
+          const isSnake = snake.some(p => p.x === x && p.y === y);
+          const isFood = food.x === x && food.y === y;
+          const bg = isFood ? 'bg-red-500' : isSnake ? 'bg-green-600' : 'bg-gray-200';
+          return <div key={i} className={`w-3 h-3 ${bg}`}></div>;
+        })}
+      </div>
+      {gameOver && <div className="mt-2 text-xs text-red-500">Game Over!</div>}
     </div>
   );
 };

--- a/tests/ComparisonForm.test.tsx
+++ b/tests/ComparisonForm.test.tsx
@@ -46,7 +46,7 @@ describe('ComparisonForm', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /compare now/i }));
 
-    expect(await screen.findByText(/Analyzing/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Checking specs/i)).toBeInTheDocument();
 
     analysis.resolve({
       isIncompatible: true,


### PR DESCRIPTION
## Summary
- show current/new device names in comparison table header
- clarify loading stages when analyzing a comparison
- enhance snake mini-game with score and self-collision
- ensure home link navigates after confirmation
- update tests for new loading message

## Testing
- `npx vitest run --reporter=dot`

------
https://chatgpt.com/codex/tasks/task_e_6877f18d70dc833081c0f3316ebad9dc