### PR TITLE
Handle truncated Gemini responses

### DIFF
--- a/src/utils/parseGeminiResponse.ts
+++ b/src/utils/parseGeminiResponse.ts
@@ -2,7 +2,8 @@ import { jsonrepair } from 'jsonrepair';
 import { GeminiParseError, GeminiTokenLimitError } from './geminiErrors';
 
 export function parseGeminiResponse(response: any): any {
-  const parts = response?.candidates?.[0]?.content?.parts;
+  const firstCandidate = response?.candidates?.[0] ?? {};
+  const parts = firstCandidate?.content?.parts;
   let text: string | undefined;
   if (Array.isArray(parts)) {
     for (const part of parts) {
@@ -13,6 +14,9 @@ export function parseGeminiResponse(response: any): any {
     }
   }
   if (!text) {
+    if (firstCandidate?.finishReason === 'MAX_TOKENS') {
+      throw new GeminiTokenLimitError('Response truncated due to token limit');
+    }
     console.error('Invalid Gemini response format:', JSON.stringify(response));
     throw new GeminiParseError('Invalid response format from Gemini');
   }

--- a/tests/parseGeminiResponse.test.ts
+++ b/tests/parseGeminiResponse.test.ts
@@ -42,4 +42,13 @@ describe('parseGeminiResponse', () => {
     const response = buildResponse('Error: token limit exceeded');
     expect(() => parseGeminiResponse(response)).toThrow(GeminiTokenLimitError);
   });
+
+  it('throws GeminiTokenLimitError when finishReason indicates max tokens', () => {
+    const response = {
+      candidates: [
+        { content: {}, finishReason: 'MAX_TOKENS' }
+      ]
+    } as any;
+    expect(() => parseGeminiResponse(response)).toThrow(GeminiTokenLimitError);
+  });
 });


### PR DESCRIPTION
## Summary
- detect token limit using `finishReason` in `parseGeminiResponse`
- add test covering `finishReason` case

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878a04c5c708330ad1cc5339b9de81e