### PR TITLE
Update busy message with time estimate

### DIFF
--- a/src/components/ComparisonFormInputs.tsx
+++ b/src/components/ComparisonFormInputs.tsx
@@ -113,7 +113,7 @@ const ComparisonFormInputs = ({
             <div className="mt-6 space-y-4 text-center">
               <p className="text-sm text-tech-gray-500">
                 {busyStage === 'checking'
-                  ? 'Checking if we have all the necessary specs...'
+                  ? 'Checking if we have all the necessary specs (this can take 1\u20113 min)...'
                   : 'Interrogating the AI and analyzing, this might take a moment...'}
               </p>
               {busyStage === 'analyzing' && <SnakeGame active={true} />}


### PR DESCRIPTION
## Summary
- add a duration hint for checking specs message in `ComparisonFormInputs`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687a1bd8cc388330a98f30fa1b963100