### PR TITLE
Handle Gemini token limit in skip dialog

### DIFF
--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -252,13 +252,22 @@ export const useComparisonForm = () => {
     } catch (error) {
       console.error('Fallback comparison failed:', error);
       logDevError('Fallback comparison failed', error);
-      toast({
-        title: 'Analysis Error',
-        description: 'Unable to analyze these products. Please try again later.',
-        variant: 'destructive'
-      });
+      if (error instanceof GeminiTokenLimitError) {
+        toast({
+          title: 'Response Too Long',
+          description: 'The AI response exceeded the token limit.',
+          variant: 'destructive'
+        });
+      } else {
+        toast({
+          title: 'Analysis Error',
+          description: 'Unable to analyze these products. Please try again later.',
+          variant: 'destructive'
+        });
+      }
     } finally {
       setShowPreciseSpecs(false);
+      setIsSubmitting(false);
     }
   };
 

--- a/tests/handleSkipPreciseSpecs.test.tsx
+++ b/tests/handleSkipPreciseSpecs.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useComparisonForm } from '../src/hooks/useComparisonForm';
+import { ComparisonResultProvider } from '../src/contexts/ComparisonResultContext';
+import { GeminiTokenLimitError } from '../src/utils/geminiErrors';
+
+vi.mock('../src/hooks/useMockData', () => ({
+  useMockData: () => ({
+    isLoading: false,
+    simulateAnalysis: vi.fn(() => Promise.reject(new GeminiTokenLimitError()))
+  })
+}));
+
+const toastMock = vi.fn();
+vi.mock('../src/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock })
+}));
+
+vi.mock('../src/services/geminiService', () => ({
+  geminiService: {
+    getProductSpecs: vi.fn(() => Promise.resolve({}))
+  }
+}));
+
+describe('handleSkipPreciseSpecs', () => {
+  it('closes dialog and shows toast on token limit error', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <ComparisonResultProvider>{children}</ComparisonResultProvider>
+    );
+    const { result } = renderHook(() => useComparisonForm(), { wrapper });
+
+    act(() => {
+      result.current.setCurrentProduct('a');
+      result.current.setNewProduct('b');
+      result.current.setShowPreciseSpecs(true);
+    });
+
+    await act(async () => {
+      await result.current.handleSkipPreciseSpecs();
+    });
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Response Too Long' })
+    );
+    expect(result.current.showPreciseSpecs).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- close precise specs dialog properly on token limit error
- surface friendly toast when AI response is too long
- add regression test for this scenario

## Testing
- `npx vitest run --reporter=json`

------
https://chatgpt.com/codex/tasks/task_e_687a2e67f3048330a562edbee607602c