### PR TITLE
Fix truncated Gemini responses

### DIFF
--- a/src/utils/parseGeminiResponse.ts
+++ b/src/utils/parseGeminiResponse.ts
@@ -21,6 +21,10 @@ export function parseGeminiResponse(response: any): any {
     throw new GeminiParseError('Invalid response format from Gemini');
   }
 
+  if (firstCandidate?.finishReason === 'MAX_TOKENS') {
+    throw new GeminiTokenLimitError('Response truncated due to token limit');
+  }
+
   const jsonMatch = text.match(/\{[\s\S]*\}/);
   if (!jsonMatch) {
     const lower = text.toLowerCase();

--- a/tests/parseGeminiResponse.test.ts
+++ b/tests/parseGeminiResponse.test.ts
@@ -51,4 +51,16 @@ describe('parseGeminiResponse', () => {
     } as any;
     expect(() => parseGeminiResponse(response)).toThrow(GeminiTokenLimitError);
   });
+
+  it('throws GeminiTokenLimitError when text is truncated but finishReason is MAX_TOKENS', () => {
+    const response = {
+      candidates: [
+        {
+          content: { parts: [{ text: '{"foo": 1' }] },
+          finishReason: 'MAX_TOKENS'
+        }
+      ]
+    } as any;
+    expect(() => parseGeminiResponse(response)).toThrow(GeminiTokenLimitError);
+  });
 });


### PR DESCRIPTION
## Summary
- treat truncated Gemini responses with `MAX_TOKENS` finishReason as token limit errors
- test for truncated response handling

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687bf9c100ec833095b8bebab0e65412