### PR TITLE
Fix loading indicator when skipping precise specs

### DIFF
--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -237,6 +237,7 @@ export const useComparisonForm = () => {
   };
 
   const handleSkipPreciseSpecs = async () => {
+    setIsSubmitting(true);
     try {
       if (pendingComparison) {
         setComparisonResult(pendingComparison);


### PR DESCRIPTION
## Summary
- set `isSubmitting` true when user chooses to skip precise spec entry
- keep disabling the loading state when done

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0dab4f28833097565da2bc9c64eb