### PR TITLE
Remove Current/New sublabels

### DIFF
--- a/src/components/ComparisonResult.tsx
+++ b/src/components/ComparisonResult.tsx
@@ -203,13 +203,11 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
                       <TableRow>
                         <TableHead className="font-bold text-tech-dark">Component</TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">
-                          <div className="text-sm font-semibold text-tech-electric mb-1">{data.currentDevice}</div>
-                          <div className="text-xs text-tech-gray-600 font-normal">Current</div>
+                          {data.currentDevice}
                         </TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">Impact</TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">
-                          <div className="text-sm font-semibold text-tech-electric mb-1">{data.newDevice}</div>
-                          <div className="text-xs text-tech-gray-600 font-normal">New</div>
+                          {data.newDevice}
                         </TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">Why Better?</TableHead>
                       </TableRow>

--- a/src/components/TechnicalView.tsx
+++ b/src/components/TechnicalView.tsx
@@ -74,16 +74,14 @@ const TechnicalView = ({ currentDevice, newDevice, specs }: TechnicalViewProps) 
               <TableRow>
                 <TableHead className="font-bold text-tech-dark">Component</TableHead>
                 <TableHead className="font-bold text-tech-dark text-center">
-                  <div className="text-sm font-semibold text-tech-electric mb-1">{currentDevice}</div>
-                  <div className="text-xs text-tech-gray-600 font-normal">Current</div>
+                  {currentDevice}
                 </TableHead>
                 <TableHead className="font-bold text-tech-dark text-center">
                   <div className="text-sm font-semibold mb-1">Impact</div>
                   <div className="text-xs text-tech-gray-600 font-normal">Better/Worse/Same</div>
                 </TableHead>
                 <TableHead className="font-bold text-tech-dark text-center">
-                  <div className="text-sm font-semibold text-tech-electric mb-1">{newDevice}</div>
-                  <div className="text-xs text-tech-gray-600 font-normal">New</div>
+                  {newDevice}
                 </TableHead>
                 <TableHead className="font-bold text-tech-dark text-center">Score</TableHead>
                 <TableHead className="font-bold text-tech-dark">Technical Details</TableHead>

--- a/tests/ComparisonResult.test.tsx
+++ b/tests/ComparisonResult.test.tsx
@@ -69,4 +69,10 @@ describe('ComparisonResult', () => {
     expect(screen.getByRole('rowheader', { name: /Battery/i })).toBeInTheDocument();
     expect(screen.getByText('Lasts longer')).toBeInTheDocument();
   });
+
+  it('does not show Current/New sublabels in headers', () => {
+    render(<ComparisonResult data={normalizedData} onReset={() => {}} />);
+    expect(screen.queryByText('Current')).toBeNull();
+    expect(screen.queryByText(/^New$/)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- drop extra labels from ComparisonResult headers
- drop extra labels from TechnicalView
- assert headers lack the extra text in tests

## Testing
- `CI=1 npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687c0ec0bbe883309cca7fe93aabfc10