### PR TITLE
Handle missing specs automatically

### DIFF
--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -122,23 +122,14 @@ export const useComparisonForm = () => {
         );
 
         if (!completeness.current.complete || !completeness.new.complete) {
-          const deviceInfo = !completeness.current.complete && !completeness.new.complete
-            ? `${currentProduct} and ${newProduct}`
-            : !completeness.current.complete
-              ? currentProduct
-              : newProduct;
-          setPreciseDevice(deviceInfo);
-          setShowPreciseSpecs(true);
-          setIsSubmitting(false);
+          await handleSkipPreciseSpecs();
           return;
         }
 
         const result = await simulateAnalysis(currentProduct, newProduct);
         if (!('isIncompatible' in result) && needsPreciseSpecs(result)) {
           setPendingComparison(result);
-          setPreciseDevice(currentProduct);
-          setShowPreciseSpecs(true);
-          setIsSubmitting(false);
+          await handleSkipPreciseSpecs();
           return;
         }
         setComparisonResult(result);


### PR DESCRIPTION
## Summary
- automatically fall back to common specs when device descriptions lack detail

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687cb51b69508330a04b41f4d75114d3