### PR TITLE
Normalize categories before comparing

### DIFF
--- a/src/utils/simplifyCategory.ts
+++ b/src/utils/simplifyCategory.ts
@@ -1,0 +1,4 @@
+export function simplifyCategory(category: string): string {
+  if (!category) return '';
+  return category.toLowerCase().split(/\s+/)[0];
+}

--- a/tests/geminiService.test.ts
+++ b/tests/geminiService.test.ts
@@ -33,4 +33,28 @@ describe('geminiService.checkComparability', () => {
     const result = await geminiService.checkComparability('iPhone', 'Samsung');
     expect(result).toEqual(second);
   });
+
+  it('normalizes multiword categories', async () => {
+    const response = {
+      comparable: true,
+      category1: 'Flagship Smartphone',
+      category2: 'Mid-range Smartphone'
+    };
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => wrap(response)
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    (geminiService as any).apiKey = 'test-key';
+
+    const result = await geminiService.checkComparability('iPhone', 'Samsung');
+    expect(result).toEqual({
+      comparable: true,
+      category1: 'flagship',
+      category2: 'mid-range'
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- tweak comparability prompt wording
- normalize `category1`/`category2` values via new `simplifyCategory` util
- apply simplified categories for retry logic
- test category simplification

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687e2c52004c83309c61613350b4a178