### PR TITLE
Make Gemini token limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Example environment variables for development
 VITE_GEMINI_API_KEY=your-api-key
+VITE_GEMINI_MAX_OUTPUT_TOKENS=8192

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cp .env.example .env
 ```
 
 The application uses the free Gemini 2.5 Flash model with a daily limit of 500 requests. The code enforces a safety threshold of 490 requests per day to avoid hitting the quota.
-Responses are limited to 4096 tokens to encourage concise answers and reduce quota usage.
+Responses are limited to 8192 tokens to encourage concise answers and reduce quota usage.
 
 ### Clarifying specifications
 If the automatic comparison doesn't provide enough specification data, the app now prompts you to enter precise specs for the device that needs clarification. This ensures the analysis is as accurate as possible.

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -23,6 +23,10 @@ class GeminiServiceClass {
   // Utilise le modèle Gemini 2.5 Flash en version gratuite
   private readonly GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
   private readonly ADMIN_EMAIL = 'votre-email@example.com'; // Email pour les alertes
+  private readonly maxOutputTokens: number = parseInt(
+    import.meta.env.VITE_GEMINI_MAX_OUTPUT_TOKENS ?? '8192',
+    10
+  );
 
   constructor() {
     this.initializeCounters();
@@ -131,7 +135,7 @@ class GeminiServiceClass {
           topK: 40,
           topP: 0.95,
           // Limit output length to keep responses concise
-          maxOutputTokens: 4096,
+          maxOutputTokens: this.maxOutputTokens,
         }
       })
     });


### PR DESCRIPTION
## Summary
- add `VITE_GEMINI_MAX_OUTPUT_TOKENS` example variable
- load the new variable in `geminiService`
- document new 8192-token limit in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885e7924ca08330bdd4698e0581dfed