### PR TITLE
Update Gemini token settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # Example environment variables for development
 VITE_GEMINI_API_KEY=your-api-key
-VITE_GEMINI_MAX_OUTPUT_TOKENS=8192
+VITE_GEMINI_MAX_OUTPUT_TOKENS=4096

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cp .env.example .env
 ```
 
 The application uses the free Gemini 2.5 Flash model with a daily limit of 500 requests. The code enforces a safety threshold of 490 requests per day to avoid hitting the quota.
-Responses are limited to 8192 tokens to encourage concise answers and reduce quota usage.
+Responses are limited to 4096 tokens to encourage concise answers and reduce quota usage.
 
 ### Clarifying specifications
 If the automatic comparison doesn't provide enough specification data, the app now prompts you to enter precise specs for the device that needs clarification. This ensures the analysis is as accurate as possible.

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -24,7 +24,7 @@ class GeminiServiceClass {
   private readonly GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
   private readonly ADMIN_EMAIL = 'votre-email@example.com'; // Email pour les alertes
   private readonly maxOutputTokens: number = parseInt(
-    import.meta.env.VITE_GEMINI_MAX_OUTPUT_TOKENS ?? '8192',
+    import.meta.env.VITE_GEMINI_MAX_OUTPUT_TOKENS ?? '4096',
     10
   );
 
@@ -264,7 +264,7 @@ Please respond with a JSON object containing comprehensive specs including:
 - Technical details
 - Release information
 
-Be accurate and comprehensive.`;
+Be accurate and comprehensive. Limit the JSON response to under 500 tokens.`;
 
     const response = await this.callGeminiAPI(prompt);
     try {


### PR DESCRIPTION
## Summary
- reduce default Gemini token limit
- instruct Gemini to keep specs JSON under 500 tokens
- document new defaults in `.env.example` and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886500627bc8330930243bcf78a0dfb