### PR TITLE
Add Gemini token limit docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # Example environment variables for development
 VITE_GEMINI_API_KEY=your-api-key
-VITE_GEMINI_MAX_OUTPUT_TOKENS=4096
+VITE_GEMINI_MAX_OUTPUT_TOKENS=4096 # lower this to shorten responses

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ cp .env.example .env
 The application uses the free Gemini 2.5 Flash model with a daily limit of 500 requests. The code enforces a safety threshold of 490 requests per day to avoid hitting the quota.
 Responses are limited to 4096 tokens to encourage concise answers and reduce quota usage.
 
+### Limiting response length
+`VITE_GEMINI_MAX_OUTPUT_TOKENS` controls the maximum number of tokens Gemini will return. It's set to `4096` in `.env.example`, but you can lower this value in your `.env` file if the answers are too long.
+
 ### Clarifying specifications
 If the automatic comparison doesn't provide enough specification data, the app now prompts you to enter precise specs for the device that needs clarification. This ensures the analysis is as accurate as possible.
 


### PR DESCRIPTION
## Summary
- document `VITE_GEMINI_MAX_OUTPUT_TOKENS` in the README
- note the variable in `.env.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688651777f9c8330b446552b6ce92ca2