### PR TITLE
feat: add leave result dialog

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,44 +1,54 @@
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useComparisonResult } from '@/contexts/ComparisonResultContext';
+import LeaveResultDialog from './LeaveResultDialog';
 
 const Header = () => {
-  const { hasResult } = useComparisonResult();
+  const { hasResult, setHasResult } = useComparisonResult();
   const navigate = useNavigate();
+  const [showDialog, setShowDialog] = useState(false);
 
   const handleHomeClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (hasResult) {
       e.preventDefault();
-      const proceed = window.confirm(
-        'You have a comparison result. Navigating away will lose it. Continue?'
-      );
-      if (proceed) {
-        navigate('/', { replace: true });
-      }
+      setShowDialog(true);
     }
   };
 
+  const handleConfirm = () => {
+    setShowDialog(false);
+    setHasResult(false);
+    navigate('/', { replace: true });
+  };
+
   return (
-    <header className="sticky top-0 z-50 w-full bg-white/90 backdrop-blur-xl border-b border-tech-gray-200/50 shadow-electric">
-      <div className="container mx-auto px-6 py-4">
-        <div className="flex items-center justify-between">
-          <Link to="/" onClick={handleHomeClick} className="flex items-center space-x-3">
-            <div className="w-8 h-8 bg-gradient-tech rounded-xl flex items-center justify-center shadow-neon">
-              <span className="text-white font-bold text-sm">IB</span>
+    <>
+      <header className="sticky top-0 z-50 w-full bg-white/90 backdrop-blur-xl border-b border-tech-gray-200/50 shadow-electric">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <Link to="/" onClick={handleHomeClick} className="flex items-center space-x-3">
+              <div className="w-8 h-8 bg-gradient-tech rounded-xl flex items-center justify-center shadow-neon">
+                <span className="text-white font-bold text-sm">IB</span>
+              </div>
+              <h1 className="text-xl font-bold bg-gradient-dark bg-clip-text text-transparent">
+                Is it Better?
+              </h1>
+            </Link>
+            <div className="hidden md:flex items-center space-x-6 text-sm">
+              <span className="bg-gradient-to-r from-tech-electric/10 to-tech-neon/10 text-tech-electric px-4 py-2 rounded-full font-semibold border border-tech-electric/20">
+                ✨ 100% Free
+              </span>
             </div>
-            <h1 className="text-xl font-bold bg-gradient-dark bg-clip-text text-transparent">
-              Is it Better?
-            </h1>
-          </Link>
-          <div className="hidden md:flex items-center space-x-6 text-sm">
-            <span className="bg-gradient-to-r from-tech-electric/10 to-tech-neon/10 text-tech-electric px-4 py-2 rounded-full font-semibold border border-tech-electric/20">
-              ✨ 100% Free
-            </span>
           </div>
         </div>
-      </div>
-    </header>
+      </header>
+      <LeaveResultDialog
+        open={showDialog}
+        onCancel={() => setShowDialog(false)}
+        onConfirm={handleConfirm}
+      />
+    </>
   );
 };
 

--- a/src/components/LeaveResultDialog.tsx
+++ b/src/components/LeaveResultDialog.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface LeaveResultDialogProps {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const LeaveResultDialog = ({ open, onCancel, onConfirm }: LeaveResultDialogProps) => {
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
+      <DialogContent className="sm:max-w-md" aria-describedby="leave-result-desc">
+        <DialogHeader>
+          <DialogTitle>Leave page?</DialogTitle>
+        </DialogHeader>
+        <DialogDescription id="leave-result-desc">
+          You have a comparison result. Navigating away will lose it. Continue?
+        </DialogDescription>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm}>OK</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default LeaveResultDialog;

--- a/tests/Header.test.tsx
+++ b/tests/Header.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -8,8 +8,7 @@ import { ComparisonResultProvider } from '../src/contexts/ComparisonResultContex
 import '@testing-library/jest-dom';
 
 describe('Header navigation', () => {
-  it('prompts before navigating when a result exists', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+  it('shows a dialog before navigating when a result exists', async () => {
     render(
       <ComparisonResultProvider initialHasResult={true}>
         <MemoryRouter>
@@ -19,7 +18,24 @@ describe('Header navigation', () => {
     );
 
     await userEvent.click(screen.getByRole('link', { name: /is it better/i }));
-    expect(confirmSpy).toHaveBeenCalled();
-    confirmSpy.mockRestore();
+    expect(
+      screen.getByText(/navigating away will lose it/i)
+    ).toBeInTheDocument();
+  });
+
+  it('closes the dialog when cancel is clicked', async () => {
+    render(
+      <ComparisonResultProvider initialHasResult={true}>
+        <MemoryRouter>
+          <Header />
+        </MemoryRouter>
+      </ComparisonResultProvider>
+    );
+
+    await userEvent.click(screen.getByRole('link', { name: /is it better/i }));
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(
+      screen.queryByText(/navigating away will lose it/i)
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add LeaveResultDialog for confirmation when leaving with results
- use dialog in Header instead of window.confirm
- adjust Header tests for new dialog behavior

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68905ca73b308330a25ffb1e556a9216