### PR TITLE
feat: add comparison reset method

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { useComparisonResult } from '@/contexts/ComparisonResultContext';
 import LeaveResultDialog from './LeaveResultDialog';
 
 const Header = () => {
-  const { hasResult, setHasResult } = useComparisonResult();
+  const { hasResult, resetResult } = useComparisonResult();
   const navigate = useNavigate();
   const [showDialog, setShowDialog] = useState(false);
 
@@ -18,7 +18,7 @@ const Header = () => {
 
   const handleConfirm = () => {
     setShowDialog(false);
-    setHasResult(false);
+    resetResult();
     navigate('/', { replace: true });
   };
 

--- a/src/contexts/ComparisonResultContext.tsx
+++ b/src/contexts/ComparisonResultContext.tsx
@@ -3,11 +3,13 @@ import React, { createContext, useContext, useState } from 'react';
 interface ComparisonResultContextValue {
   hasResult: boolean;
   setHasResult: (value: boolean) => void;
+  resetResult: () => void;
 }
 
 const ComparisonResultContext = createContext<ComparisonResultContextValue>({
   hasResult: false,
   setHasResult: () => {},
+  resetResult: () => {},
 });
 
 interface ProviderProps {
@@ -17,8 +19,9 @@ interface ProviderProps {
 
 export const ComparisonResultProvider = ({ children, initialHasResult = false }: ProviderProps) => {
   const [hasResult, setHasResult] = useState(initialHasResult);
+  const resetResult = () => setHasResult(false);
   return (
-    <ComparisonResultContext.Provider value={{ hasResult, setHasResult }}>
+    <ComparisonResultContext.Provider value={{ hasResult, setHasResult, resetResult }}>
       {children}
     </ComparisonResultContext.Provider>
   );

--- a/src/hooks/useComparisonForm.ts
+++ b/src/hooks/useComparisonForm.ts
@@ -51,7 +51,7 @@ export const useComparisonForm = () => {
   const [category, setCategory] = useState<string>('computer');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { setHasResult } = useComparisonResult();
+  const { setHasResult, resetResult } = useComparisonResult();
 
   const { toast } = useToast();
 
@@ -267,7 +267,7 @@ export const useComparisonForm = () => {
     setCurrentProduct('');
     setNewProduct('');
     setComparisonResult(null);
-    setHasResult(false);
+    resetResult();
     setShowQueueStatus(false);
     setShowProductNotFound(false);
     setShowQueue(false);


### PR DESCRIPTION
## Summary
- add resetResult to comparison result context
- use resetResult in form reset logic
- clear comparison result when confirming dialog in header

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68906093487883309125f73a89f7fe34