### PR TITLE
test: update Header navigation dialog

### DIFF
--- a/tests/Header.test.tsx
+++ b/tests/Header.test.tsx
@@ -1,41 +1,45 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import Header from '../src/components/Header';
-import { ComparisonResultProvider } from '../src/contexts/ComparisonResultContext';
+import {
+  ComparisonResultProvider,
+  useComparisonResult,
+} from '../src/contexts/ComparisonResultContext';
 import '@testing-library/jest-dom';
 
+const LocationAndResult = () => {
+  const location = useLocation();
+  const { hasResult } = useComparisonResult();
+  return (
+    <>
+      <span data-testid="location">{location.pathname}</span>
+      <span data-testid="has-result">{String(hasResult)}</span>
+    </>
+  );
+};
+
 describe('Header navigation', () => {
-  it('shows a dialog before navigating when a result exists', async () => {
+  it('opens dialog on logo click and navigates home on confirm', async () => {
     render(
       <ComparisonResultProvider initialHasResult={true}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={['/result']}>
           <Header />
+          <LocationAndResult />
         </MemoryRouter>
       </ComparisonResultProvider>
     );
 
     await userEvent.click(screen.getByRole('link', { name: /is it better/i }));
-    expect(
-      screen.getByText(/navigating away will lose it/i)
-    ).toBeInTheDocument();
-  });
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
 
-  it('closes the dialog when cancel is clicked', async () => {
-    render(
-      <ComparisonResultProvider initialHasResult={true}>
-        <MemoryRouter>
-          <Header />
-        </MemoryRouter>
-      </ComparisonResultProvider>
-    );
+    await userEvent.click(screen.getByRole('button', { name: /ok/i }));
 
-    await userEvent.click(screen.getByRole('link', { name: /is it better/i }));
-    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
-    expect(
-      screen.queryByText(/navigating away will lose it/i)
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/');
+      expect(screen.getByTestId('has-result')).toHaveTextContent('false');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- rewrite Header test to open dialog on logo click
- confirm dialog to navigate home and reset result state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e02ec67c8330b7ee16a282873904