### PR TITLE
feat: add coffee support link

### DIFF
--- a/src/components/ComparisonResult.tsx
+++ b/src/components/ComparisonResult.tsx
@@ -10,7 +10,7 @@ import {
   TableHead,
   TableCell,
 } from '@/components/ui/table';
-import { CheckCircle, XCircle, AlertTriangle, ShoppingCart } from 'lucide-react';
+import { CheckCircle, XCircle, AlertTriangle, ShoppingCart, Coffee } from 'lucide-react';
 import TechnicalView from './TechnicalView';
 import { extractReasonCategory } from '@/utils/reasons';
 
@@ -251,6 +251,18 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
             )}
           </>
         )}
+
+        <div className="text-center mt-6">
+          <a
+            href="https://buymeacoffee.com/enkio"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center px-6 py-3 bg-yellow-400 text-black font-semibold rounded-lg shadow hover:bg-yellow-500 transition-colors"
+          >
+            <Coffee className="mr-2 h-5 w-5" />
+            Buy Me A Coffee
+          </a>
+        </div>
 
         {/* Bouton pour recommencer */}
         <div className="text-center">

--- a/tests/ComparisonResult.test.tsx
+++ b/tests/ComparisonResult.test.tsx
@@ -75,4 +75,12 @@ describe('ComparisonResult', () => {
     expect(screen.queryByText('Current')).toBeNull();
     expect(screen.queryByText(/^New$/)).toBeNull();
   });
+
+  it('renders Buy Me A Coffee link with correct attributes', () => {
+    render(<ComparisonResult data={normalizedData} onReset={() => {}} />);
+    const link = screen.getByRole('link', { name: /Buy Me A Coffee/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://buymeacoffee.com/enkio');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
 });


### PR DESCRIPTION
## Summary
- add Buy Me A Coffee button to comparison results
- cover support link with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68911fbfacec8330b36bb2f754b284f1