### PR TITLE
Handle zero spec score gracefully

### DIFF
--- a/src/components/TechnicalView.tsx
+++ b/src/components/TechnicalView.tsx
@@ -47,6 +47,7 @@ const TechnicalView = ({ currentDevice, newDevice, specs }: TechnicalViewProps) 
   };
 
   const getScoreColor = (score: number) => {
+    if (score === 0) return 'text-tech-gray-600 font-semibold';
     if (score >= 80) return 'text-green-600 font-bold';
     if (score >= 60) return 'text-yellow-600 font-semibold';
     return 'text-red-600 font-semibold';
@@ -112,7 +113,9 @@ const TechnicalView = ({ currentDevice, newDevice, specs }: TechnicalViewProps) 
                     <div className="text-xs text-tech-gray-600 mt-1">{spec.new.technical}</div>
                   </TableCell>
                   <TableCell className="text-center">
-                    <span className={getScoreColor(spec.score)}>{spec.score}/100</span>
+                    <span className={getScoreColor(spec.score)}>
+                      {spec.score === 0 ? '-' : `${spec.score}/100`}
+                    </span>
                   </TableCell>
                   <TableCell className="text-sm text-tech-gray-600 max-w-xs">
                     {spec.details}

--- a/tests/ComparisonResult.test.tsx
+++ b/tests/ComparisonResult.test.tsx
@@ -83,4 +83,33 @@ describe('ComparisonResult', () => {
     expect(link).toHaveAttribute('href', 'https://buymeacoffee.com/enkio');
     expect(link).toHaveAttribute('target', '_blank');
   });
+
+  it('shows a dash instead of 0/100 when a spec score is 0', async () => {
+    const zeroScoreData = {
+      ...mockData,
+      connoisseurSpecs: [
+        {
+          category: 'CPU',
+          currentValue: 'A1',
+          currentTechnical: 'specA',
+          newValue: 'B1',
+          newTechnical: 'specB',
+          improvement: 'same' as const,
+          score: 0,
+          details: 'Equal',
+        },
+      ],
+    };
+    const normalizedZeroScoreData = {
+      ...zeroScoreData,
+      connoisseurSpecs: normalizeConnoisseurSpecs(zeroScoreData.connoisseurSpecs),
+    };
+
+    render(<ComparisonResult data={normalizedZeroScoreData} onReset={() => {}} />);
+
+    await userEvent.click(screen.getByRole('switch'));
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.queryByText('0/100')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Show `-` instead of `0/100` in TechnicalView when a spec score is 0
- Use neutral text color for zero scores
- Test that comparison results render a dash when score is 0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68913514890c8330aba327322de81887