### PR TITLE
Format device names in comparison results

### DIFF
--- a/src/components/ComparisonResult.tsx
+++ b/src/components/ComparisonResult.tsx
@@ -13,6 +13,7 @@ import {
 import { CheckCircle, XCircle, AlertTriangle, ShoppingCart, Coffee } from 'lucide-react';
 import TechnicalView from './TechnicalView';
 import { extractReasonCategory } from '@/utils/reasons';
+import { formatDeviceName } from '@/utils/strings';
 
 interface ComparisonData {
   currentDevice: string;
@@ -45,6 +46,8 @@ interface ComparisonResultProps {
 
 const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
   const [isConnoisseurView, setIsConnoisseurView] = useState(false);
+  const currentDeviceName = formatDeviceName(data.currentDevice);
+  const newDeviceName = formatDeviceName(data.newDevice);
 
   const getRecommendationColor = () => {
     switch (data.recommendation) {
@@ -108,7 +111,7 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
 
   const handleBuyClick = () => {
     // Ici on pourrait ajouter le tracking analytics et rediriger vers le lien d'affiliation
-    console.log('Affiliate link clicked for:', data.newDevice);
+    console.log('Affiliate link clicked for:', newDeviceName);
     // window.open(affiliateLink, '_blank');
   };
 
@@ -137,7 +140,7 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
                   className="inline-flex items-center px-8 py-4 bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white font-bold text-lg rounded-xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300 group"
                 >
                   <ShoppingCart className="mr-3 h-5 w-5 group-hover:animate-bounce" />
-                  Check {data.newDevice} on Amazon
+                  Check {newDeviceName} on Amazon
                 </button>
                 <p className="text-xs text-tech-gray-500 mt-2">
                   Affiliate link - We may earn a commission
@@ -171,8 +174,8 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
         {/* Conditional View */}
         {isConnoisseurView ? (
           <TechnicalView
-            currentDevice={data.currentDevice}
-            newDevice={data.newDevice}
+            currentDevice={currentDeviceName}
+            newDevice={newDeviceName}
             specs={data.connoisseurSpecs}
           />
         ) : (
@@ -192,11 +195,11 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
                       <TableRow>
                         <TableHead className="font-bold text-tech-dark">Component</TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">
-                          {data.currentDevice}
+                          {currentDeviceName}
                         </TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">Impact</TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">
-                          {data.newDevice}
+                          {newDeviceName}
                         </TableHead>
                         <TableHead className="font-bold text-tech-dark text-center">Why Better?</TableHead>
                       </TableRow>

--- a/src/components/TechnicalView.tsx
+++ b/src/components/TechnicalView.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { formatDeviceName } from '@/utils/strings';
 
 interface TechnicalSpec {
   category: string;
@@ -26,6 +27,8 @@ interface TechnicalViewProps {
 }
 
 const TechnicalView = ({ currentDevice, newDevice, specs }: TechnicalViewProps) => {
+  const currentDeviceName = formatDeviceName(currentDevice);
+  const newDeviceName = formatDeviceName(newDevice);
   const getImprovementIcon = (improvement: string) => {
     switch (improvement) {
       case 'better': return (
@@ -75,14 +78,14 @@ const TechnicalView = ({ currentDevice, newDevice, specs }: TechnicalViewProps) 
               <TableRow>
                 <TableHead className="font-bold text-tech-dark">Component</TableHead>
                 <TableHead className="font-bold text-tech-dark text-center">
-                  {currentDevice}
+                  {currentDeviceName}
                 </TableHead>
                 <TableHead className="font-bold text-tech-dark text-center">
                   <div className="text-sm font-semibold mb-1">Impact</div>
                   <div className="text-xs text-tech-gray-600 font-normal">Better/Worse/Same</div>
                 </TableHead>
                 <TableHead className="font-bold text-tech-dark text-center">
-                  {newDevice}
+                  {newDeviceName}
                 </TableHead>
                 <TableHead className="font-bold text-tech-dark text-center">Score</TableHead>
                 <TableHead className="font-bold text-tech-dark">Technical Details</TableHead>

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,0 +1,7 @@
+export function formatDeviceName(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}

--- a/tests/ComparisonResult.test.tsx
+++ b/tests/ComparisonResult.test.tsx
@@ -112,4 +112,17 @@ describe('ComparisonResult', () => {
     expect(screen.getByText('-')).toBeInTheDocument();
     expect(screen.queryByText('0/100')).toBeNull();
   });
+
+  it('formats device names in table headers', async () => {
+    const messy = ' messy   name ';
+    const messyData = {
+      ...normalizedData,
+      currentDevice: messy,
+      newDevice: messy,
+    };
+    render(<ComparisonResult data={messyData} onReset={() => {}} />);
+    expect(screen.getAllByRole('columnheader', { name: 'Messy Name' })).toHaveLength(2);
+    await userEvent.click(screen.getByRole('switch'));
+    expect(screen.getAllByRole('columnheader', { name: 'Messy Name' })).toHaveLength(2);
+  });
 });

--- a/tests/strings.test.ts
+++ b/tests/strings.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { formatDeviceName } from '../src/utils/strings';
+
+describe('formatDeviceName', () => {
+  it('trims whitespace and title-cases the name', () => {
+    expect(formatDeviceName(' messy   name ')).toBe('Messy Name');
+  });
+});


### PR DESCRIPTION
## Summary
- add `formatDeviceName` helper to normalize device names
- use helper in comparison flow and views so headers show clean names
- cover formatting with new unit tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68913a7ac5108330a0fecbce7e4c8ed9