### PR TITLE
Add automated sitemap generation and robots.txt update

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/generate-sitemap.mjs",
     "build": "vite build && react-snap",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,5 @@ Allow: /
 
 User-agent: *
 Allow: /
+
+Sitemap: https://domaine.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://domaine.com/</loc>
+  </url>
+  <url>
+    <loc>https://domaine.com/contact</loc>
+  </url>
+  <url>
+    <loc>https://domaine.com/privacy</loc>
+  </url>
+  <url>
+    <loc>https://domaine.com/terms</loc>
+  </url>
+</urlset>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,17 @@
+import { readFileSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const baseUrl = "https://domaine.com";
+
+const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
+const routes = Array.isArray(pkg.reactSnap?.include) ? pkg.reactSnap.include : [];
+
+const urls = routes
+  .map((route) => `  <url>\n    <loc>${baseUrl}${route}</loc>\n  </url>`)
+  .join("\n");
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+
+writeFileSync(join(__dirname, "..", "public", "sitemap.xml"), sitemap);


### PR DESCRIPTION
## Summary
- generate sitemap from `reactSnap.include` via prebuild script
- add `sitemap.xml` to public assets and reference it in `robots.txt`

## Testing
- `npx vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689251438c1c83309230b6e10608d745