### PR TITLE
feat: add structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,14 @@
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content="/placeholder.svg" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Is it Better?",
+        "url": "https://isitbetter.com/"
+      }
+    </script>
   </head>
 
   <body>

--- a/src/components/ComparisonResult.tsx
+++ b/src/components/ComparisonResult.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -48,6 +48,46 @@ const ComparisonResult = ({ data, onReset }: ComparisonResultProps) => {
   const [isConnoisseurView, setIsConnoisseurView] = useState(false);
   const currentDeviceName = formatDeviceName(data.currentDevice);
   const newDeviceName = formatDeviceName(data.newDevice);
+
+  const jsonLd = useMemo(() => {
+    const specs = data.connoisseurSpecs ?? [];
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      itemListElement: [
+        {
+          '@type': 'Product',
+          name: currentDeviceName,
+          position: 1,
+          additionalProperty: specs.map((spec) => ({
+            '@type': 'PropertyValue',
+            name: spec.subcategory ? `${spec.category} ${spec.subcategory}` : spec.category,
+            value: spec.current.value,
+          })),
+        },
+        {
+          '@type': 'Product',
+          name: newDeviceName,
+          position: 2,
+          additionalProperty: specs.map((spec) => ({
+            '@type': 'PropertyValue',
+            name: spec.subcategory ? `${spec.category} ${spec.subcategory}` : spec.category,
+            value: spec.new.value,
+          })),
+        },
+      ],
+    };
+  }, [data.connoisseurSpecs, currentDeviceName, newDeviceName]);
+
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.text = JSON.stringify(jsonLd);
+    document.head.appendChild(script);
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, [jsonLd]);
 
   const getRecommendationColor = () => {
     switch (data.recommendation) {


### PR DESCRIPTION
## Summary
- add WebSite JSON-LD to main index
- generate comparison ItemList JSON-LD with specs

## Testing
- `npm test`
- `npm run lint`
- `curl -X POST -H "Content-Type: text/html" --data-binary @index.html https://validator.schema.org/validate?parser=html` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689264ab0474833084f6c9428a9150ef