### PR TITLE
feat: proxy Gemini requests through backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # Example environment variables for development
-VITE_GEMINI_API_KEY=your-api-key
 VITE_GEMINI_MAX_OUTPUT_TOKENS=1000 # lower this to shorten responses and leave output margin
 VITE_BACKEND_URL=http://localhost:3001
+# GEMINI_API_KEY is used by the Express backend and must be set in your environment before starting the server

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ npm install
 
 # Configure environment variables
 cp .env.example .env
-# Edit .env and set VITE_GEMINI_API_KEY=<your Gemini key>
 # Optionally set VITE_BACKEND_URL (defaults to http://localhost:3001)
+# Set GEMINI_API_KEY in your environment before starting the server
 ```
 
 ### Development
@@ -35,8 +35,8 @@ cp .env.example .env
 Run the front-end and quota server in separate terminals:
 
 ```sh
-npm run dev       # Vite dev server
-npm run server    # Express quota server on port 3001
+npm run dev                       # Vite dev server
+GEMINI_API_KEY=your-api-key npm run server    # Express quota server on port 3001
 ```
 
 Ensure `VITE_BACKEND_URL` in `.env` matches the port used by the server.
@@ -70,12 +70,7 @@ Ensure `VITE_BACKEND_URL` in `.env` matches the port used by the server.
 
 ## Configuration
 
-Create a `.env` file based on `.env.example` and provide your Gemini API key:
-
-```bash
-cp .env.example .env
-# Edit .env and set VITE_GEMINI_API_KEY=<your Gemini key>
-```
+Create a `.env` file based on `.env.example` for front-end settings. The Gemini API key must be provided to the backend via the `GEMINI_API_KEY` environment variable before starting the server.
 
 The application uses the free Gemini 2.5 Flash model with a daily limit of 500 requests. The code enforces a safety threshold of 490 requests per day to avoid hitting the quota. Responses are limited to 4096 tokens to encourage concise answers and reduce quota usage.
 

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,9 @@ const DIST_PATH = path.resolve(__dirname, '../dist');
 const PORT = process.env.PORT || 3001;
 const DAILY_LIMIT = parseInt(process.env.DAILY_LIMIT || '490', 10);
 const DATA_FILE = path.join(__dirname, 'usage.json');
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const GEMINI_API_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
 
 let usage = { date: '', count: 0 };
 
@@ -62,6 +65,47 @@ app.post('/api/increment', (req, res) => {
   usage.count += 1;
   saveUsage();
   res.json({ allowed: true, used: usage.count, remaining: DAILY_LIMIT - usage.count, limit: DAILY_LIMIT });
+});
+
+app.post('/api/gemini', async (req, res) => {
+  if (!GEMINI_API_KEY) {
+    return res.status(500).json({ error: 'Gemini API key not configured' });
+  }
+
+  const { prompt, maxOutputTokens } = req.body;
+
+  try {
+    const response = await fetch(`${GEMINI_API_URL}?key=${GEMINI_API_KEY}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [{ text: prompt }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.7,
+          topK: 40,
+          topP: 0.95,
+          maxOutputTokens: maxOutputTokens ?? 4096,
+        },
+      }),
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      console.error('Gemini API error:', data);
+      return res.status(500).json({ error: 'Gemini API request failed' });
+    }
+
+    res.json(data);
+  } catch (err) {
+    console.error('Error calling Gemini API:', err);
+    res.status(500).json({ error: 'Failed to fetch from Gemini API' });
+  }
 });
 
 app.use(express.static(DIST_PATH));

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_GEMINI_API_KEY: string;
+  readonly VITE_BACKEND_URL: string;
+  readonly VITE_GEMINI_MAX_OUTPUT_TOKENS: string;
 }
 
 interface ImportMeta {

--- a/tests/geminiService.test.ts
+++ b/tests/geminiService.test.ts
@@ -29,9 +29,6 @@ describe('geminiService.checkComparability', () => {
 
     vi.stubGlobal('fetch', fetchMock);
 
-    // Bypass API key check
-    (geminiService as any).apiKey = 'test-key';
-
     const result = await geminiService.checkComparability('iPhone', 'Samsung');
     expect(result).toEqual(second);
   });
@@ -49,8 +46,6 @@ describe('geminiService.checkComparability', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => wrap(response) });
 
     vi.stubGlobal('fetch', fetchMock);
-
-    (geminiService as any).apiKey = 'test-key';
 
     const result = await geminiService.checkComparability('iPhone', 'Samsung');
     expect(result).toEqual({


### PR DESCRIPTION
## Summary
- route Gemini prompts through new backend `/api/gemini` endpoint using server-side key
- update front-end service to call backend proxy instead of Google API directly
- document server key setup and remove client-side `VITE_GEMINI_API_KEY`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689282da7ea883308dfdee46fb6bfaa3